### PR TITLE
VRA-30: add GPU objective/stability contract + probe stub

### DIFF
--- a/Golden Draft/docs/gpu/objective_contract_v1.md
+++ b/Golden Draft/docs/gpu/objective_contract_v1.md
@@ -1,7 +1,8 @@
 # GPU Objective + Stability/Metrics Contract v1
 
 Contract ID: `objective_contract_v1`
-Path: `docs/gpu/objective_contract_v1.md`
+Path (relative to `Golden Draft/`): `docs/gpu/objective_contract_v1.md`
+Repo path: `Golden Draft/docs/gpu/objective_contract_v1.md`
 
 This contract defines what a **valid GPU capacity/throughput run** is and the
 minimum artifacts and metrics required to compare results. All GPU runs should
@@ -124,7 +125,10 @@ Minimum artifact set (per run):
 ## E) CLI Interface Contract (minimal)
 
 The **probe harness `--help` must reference this contract**:
-`docs/gpu/objective_contract_v1.md`
+`docs/gpu/objective_contract_v1.md` (relative to `Golden Draft/`)
+
+Repo path (for humans/tools from repo root):
+`Golden Draft/docs/gpu/objective_contract_v1.md`
 
 The full CLI implementation is **out of scope** for this contract and will be
 implemented in VRA‑32.
@@ -142,7 +146,7 @@ implemented in VRA‑32.
 
 ## G) Acceptance Checklist (VRA‑30)
 
-- `docs/gpu/objective_contract_v1.md` exists.
+- `Golden Draft/docs/gpu/objective_contract_v1.md` exists.
 - Doc includes objective metric, stability gates, artifact schema, and examples.
 - Probe harness `--help` references this contract path.
 - Future GPU runs reference this contract (no random baselines).

--- a/Golden Draft/tools/gpu_capacity_probe_stub.py
+++ b/Golden Draft/tools/gpu_capacity_probe_stub.py
@@ -1,19 +1,26 @@
 import argparse
 
-CONTRACT_PATH = "docs/gpu/objective_contract_v1.md"
+CONTRACT_PATH_REL_GOLDEN_DRAFT = "docs/gpu/objective_contract_v1.md"
+CONTRACT_REPO_PATH = "Golden Draft/docs/gpu/objective_contract_v1.md"
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(
         prog="gpu_capacity_probe_stub",
-        description=f"Not implemented. Contract: {CONTRACT_PATH}",
-        epilog=f"See {CONTRACT_PATH}",
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=(
+            "Not implemented; see VRA-32.\n"
+            f"Contract (relative to Golden Draft/): {CONTRACT_PATH_REL_GOLDEN_DRAFT}\n"
+            f"Repo path: {CONTRACT_REPO_PATH}"
+        ),
+        epilog=f"See {CONTRACT_PATH_REL_GOLDEN_DRAFT}",
     )
     parser.parse_args()
-    print(f"Not implemented; see VRA-32. Contract: {CONTRACT_PATH}")
+    print("Not implemented; see VRA-32.")
+    print(f"Contract (relative to Golden Draft/): {CONTRACT_PATH_REL_GOLDEN_DRAFT}")
+    print(f"Repo path: {CONTRACT_REPO_PATH}")
     return 2
 
 
 if __name__ == "__main__":
     raise SystemExit(main())
-


### PR DESCRIPTION
Closes #5

Summary:
- Adds a GPU objective + stability/metrics contract.
- Adds an explicit stub probe entrypoint whose `--help` points at the contract (implementation lands in VRA-32).

Files (2):
- `Golden Draft/docs/gpu/objective_contract_v1.md`
- `Golden Draft/tools/gpu_capacity_probe_stub.py`

Commits:
- Original (pre-cleanup refs): 78439b789871fcb700d4d8c89ffe08d8ac299897, 0b2021efb7313281700ddcc9c2632aaa3acd4d2f
- Clean cherry-picks on `vra-30-only`: 7d776d9d3a93452c479738c81588a7fb075855f4, b353cb1b940d11cac9c4f3b062471719366a02b8


---

Roadmap linkage:
Closes #41

