### PR TITLE
chore(version): bump build to 2.10.575 (post VRA-30)

### DIFF
--- a/VERSION.json
+++ b/VERSION.json
@@ -1,5 +1,5 @@
 {
   "major": 2,
   "minor": 10,
-  "build": 574
+  "build": 575
 }


### PR DESCRIPTION
Post-merge build tick for VRA-30. VRA-30 PR #6 intentionally kept pure (2 files).