### PR TITLE
VRA-31: workload schema v1 + stable workload_id + OD1 templates

### DIFF
--- a/Golden Draft/docs/gpu/workload_schema_v1.md
+++ b/Golden Draft/docs/gpu/workload_schema_v1.md
@@ -1,0 +1,148 @@
+# GPU Workload Schema v1 (AntSpec + ColonySpec)
+
+This document defines a **contract-first** workload abstraction for VRAXION GPU runs.
+
+- **VRA-31 scope:** define **what workload** is being run (explicit knobs + stable ID).
+- **VRA-30 scope:** define **how runs are measured and validated** (objective + stability gates + artifacts).
+
+If you are running GPU capacity/throughput characterization, you must reference:
+- Workload definition (this doc): `docs/gpu/workload_schema_v1.md`
+- Objective/stability contract (VRA-30): `docs/gpu/objective_contract_v1.md`
+
+> Paths above are relative to `Golden Draft/`. Repo paths are:
+> - `Golden Draft/docs/gpu/workload_schema_v1.md`
+> - `Golden Draft/docs/gpu/objective_contract_v1.md`
+
+---
+
+## 1) Purpose & Scope
+
+This schema exists to prevent "random" / implicit knob choices (ring length, slot dim, dtype, cadence, batch size, etc.)
+from silently changing between runs.
+
+Every workload spec:
+- is **strictly validated** (unknown keys are rejected),
+- maps to a deterministic, stable **`workload_id`**, and
+- can be used as an input to future probe/sweep tooling (VRA-32 / VRA-36+).
+
+This ticket **does not** execute runs or collect GPU data.
+
+---
+
+## 2) Schema: `workload_schema_v1`
+
+### 2.1 Top-level JSON shape
+
+```json
+{
+  "schema_version": "workload_schema_v1",
+  "ant_spec": { "..." : "..." },
+  "colony_spec": { "..." : "..." },
+  "name": "optional human label",
+  "notes": "optional notes"
+}
+```
+
+`name` / `notes` are allowed but **excluded from the workload ID**.
+
+### 2.2 AntSpec (shape / footprint knobs)
+
+AntSpec captures model/shape and precision choices that materially affect VRAM footprint and compute.
+
+Required keys (and env mapping):
+
+| Key | Type | Meaning | Maps to env |
+|---|---:|---|---|
+| `ring_len` | int (>=1) | ring length | `VRX_RING_LEN` |
+| `slot_dim` | int (>=1) | slot dimension | `VRX_SLOT_DIM` |
+| `ptr_dtype` | enum | pointer dtype | `VRX_PTR_DTYPE` |
+| `precision` | enum | math precision mode | `VRX_PRECISION` |
+
+Allowed `ptr_dtype` values (aligned with `Golden Code/vraxion/settings.py`): `fp64`, `fp32`, `fp16`, `bf16`.
+
+Allowed `precision` values: `fp64`, `fp32`, `fp16`, `bf16`, `amp`.
+
+**Note on `precision="amp"`:** this selects autocast behavior; the underlying math dtype can be device-dependent.
+It is still part of the workload ID because it changes runtime behavior.
+
+Optional keys (allowed but excluded from ID): `name`, `notes`.
+
+### 2.3 ColonySpec (workload / cadence knobs)
+
+ColonySpec captures workload and cadence parameters that materially affect compute.
+
+Required keys (and env mapping):
+
+| Key | Type | Meaning | Maps to env |
+|---|---:|---|---|
+| `seq_len` | int (>=1) | sequence length used for accounting | (semantic; often matches `synth_len`) |
+| `synth_len` | int (>=1) | synthetic sequence length | `VRX_SYNTH_LEN` |
+| `batch_size` | int (>=1) | batch size | `VRX_BATCH_SIZE` |
+| `ptr_update_every` | int (>=1) | pointer update cadence | `VRX_PTR_UPDATE_EVERY` |
+| `state_loop_samples` | int (>=0) | optional additional compute loop | `VRX_STATE_LOOP_SAMPLES` |
+
+Optional keys (allowed but excluded from ID): `name`, `notes`.
+
+---
+
+## 3) Strict validation rules (important)
+
+- Unknown keys at top-level, `ant_spec`, or `colony_spec` are **errors**.
+- No implicit coercion:
+  - `"8192"` (string) is **not** an int.
+  - `" fp32 "` is **not** a valid enum value.
+- Validation failures are treated as "invalid workload spec" and must block a run.
+
+---
+
+## 4) Stable `workload_id` computation
+
+The stable ID is computed from:
+- `schema_version`
+- required keys of `ant_spec`
+- required keys of `colony_spec`
+
+Excluded (do not affect ID):
+- any `name` / `notes` fields (top-level and nested)
+
+Algorithm (implemented in `tools/workload_id.py`):
+1) Canonicalize spec (drop optional fields; validate types/keys/enums).
+2) Serialize canonical JSON with:
+   - sorted keys
+   - separators `(",", ":")`
+   - ASCII only (`ensure_ascii=True`)
+3) Hash: SHA-256 over UTF-8 bytes
+4) ID: `wl_v1_` + first 12 hex chars of the digest
+
+---
+
+## 5) Canonical OD1 templates (small / real / stress)
+
+Templates live in `workloads/` (relative to `Golden Draft/`):
+- `workloads/od1_small_v1.json`
+- `workloads/od1_real_v1.json` (matches current defaults where defaults exist)
+- `workloads/od1_stress_v1.json`
+
+Compute the ID (example):
+
+```bash
+cd "Golden Draft"
+python tools/workload_id.py workloads/od1_real_v1.json
+```
+
+**Note:** `od1_stress_v1.json` may OOM on smaller GPUs. That is expected; it exists to probe the limiter/guardrails.
+
+---
+
+## 6) Relationship to the objective/stability contract (VRA-30)
+
+- This schema standardizes **what workload** is being attempted.
+- The objective/stability contract (`docs/gpu/objective_contract_v1.md`) standardizes:
+  - what metrics are recorded,
+  - what constitutes PASS/FAIL,
+  - and which artifacts must be emitted per run.
+
+Future harness/sweep code must use both:
+- **Workload schema** → sets knobs + stable IDs
+- **Objective contract** → ensures runs are valid and comparable
+

--- a/Golden Draft/tests/test_workload_id.py
+++ b/Golden Draft/tests/test_workload_id.py
@@ -1,0 +1,139 @@
+"""Tests for the VRA-31 workload ID contract (stdlib-only)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+import conftest  # noqa: F401  (import side-effect: sys.path bootstrap)
+
+from tools import workload_id
+
+
+class TestWorkloadId(unittest.TestCase):
+    def test_same_id_different_key_order(self) -> None:
+        spec_a = json.loads(
+            """
+            {
+              "schema_version": "workload_schema_v1",
+              "ant_spec": {
+                "ring_len": 8192,
+                "slot_dim": 576,
+                "ptr_dtype": "fp64",
+                "precision": "fp32"
+              },
+              "colony_spec": {
+                "seq_len": 256,
+                "synth_len": 256,
+                "batch_size": 16,
+                "ptr_update_every": 1,
+                "state_loop_samples": 0
+              }
+            }
+            """
+        )
+        spec_b = json.loads(
+            """
+            {
+              "colony_spec": {
+                "state_loop_samples": 0,
+                "ptr_update_every": 1,
+                "batch_size": 16,
+                "synth_len": 256,
+                "seq_len": 256
+              },
+              "ant_spec": {
+                "precision": "fp32",
+                "ptr_dtype": "fp64",
+                "slot_dim": 576,
+                "ring_len": 8192
+              },
+              "schema_version": "workload_schema_v1"
+            }
+            """
+        )
+
+        wid_a = workload_id.compute_workload_id(workload_id.canonicalize_spec(spec_a))
+        wid_b = workload_id.compute_workload_id(workload_id.canonicalize_spec(spec_b))
+        self.assertEqual(wid_a, wid_b)
+
+    def test_required_field_change_changes_id(self) -> None:
+        base = {
+            "schema_version": "workload_schema_v1",
+            "ant_spec": {"ring_len": 8192, "slot_dim": 576, "ptr_dtype": "fp64", "precision": "fp32"},
+            "colony_spec": {
+                "seq_len": 256,
+                "synth_len": 256,
+                "batch_size": 16,
+                "ptr_update_every": 1,
+                "state_loop_samples": 0,
+            },
+        }
+        base_id = workload_id.compute_workload_id(workload_id.canonicalize_spec(dict(base)))
+
+        changed = json.loads(json.dumps(base))
+        changed["ant_spec"]["ring_len"] = 8193
+        changed_id = workload_id.compute_workload_id(workload_id.canonicalize_spec(changed))
+        self.assertNotEqual(base_id, changed_id)
+
+    def test_optional_name_notes_excluded(self) -> None:
+        base = {
+            "schema_version": "workload_schema_v1",
+            "ant_spec": {"ring_len": 8192, "slot_dim": 576, "ptr_dtype": "fp64", "precision": "fp32"},
+            "colony_spec": {
+                "seq_len": 256,
+                "synth_len": 256,
+                "batch_size": 16,
+                "ptr_update_every": 1,
+                "state_loop_samples": 0,
+            },
+        }
+        with_notes = json.loads(json.dumps(base))
+        with_notes["name"] = "example"
+        with_notes["notes"] = "hello"
+        with_notes["ant_spec"]["name"] = "ant"
+        with_notes["colony_spec"]["notes"] = "col"
+
+        wid_a = workload_id.compute_workload_id(workload_id.canonicalize_spec(base))
+        wid_b = workload_id.compute_workload_id(workload_id.canonicalize_spec(with_notes))
+        self.assertEqual(wid_a, wid_b)
+
+    def test_unknown_key_rejected(self) -> None:
+        bad = {
+            "schema_version": "workload_schema_v1",
+            "ant_spec": {"ring_len": 8192, "slot_dim": 576, "ptr_dtype": "fp64", "precision": "fp32"},
+            "colony_spec": {
+                "seq_len": 256,
+                "synth_len": 256,
+                "batch_size": 16,
+                "ptr_update_every": 1,
+                "state_loop_samples": 0,
+            },
+            "unexpected": 1,
+        }
+        with self.assertRaises(ValueError):
+            workload_id.canonicalize_spec(bad)
+
+    def test_cli_smoke_real_template(self) -> None:
+        draft_root = Path(__file__).resolve().parents[1]
+        script = draft_root / "tools" / "workload_id.py"
+        tpl = draft_root / "workloads" / "od1_real_v1.json"
+
+        proc = subprocess.run(
+            [sys.executable, str(script), str(tpl)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        wid = proc.stdout.strip()
+        self.assertTrue(wid.startswith("wl_v1_"))
+        self.assertEqual(len(wid), len("wl_v1_") + 12)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/Golden Draft/tools/workload_id.py
+++ b/Golden Draft/tools/workload_id.py
@@ -1,0 +1,164 @@
+"""Workload spec validation + canonical stable workload ID (VRA-31).
+
+Stdlib-only by design.
+
+This module defines:
+- schema_version: workload_schema_v1
+- strict validation (unknown keys are errors; no implicit coercion)
+- deterministic ID: sha256(canonical_json) -> wl_v1_<12 hex>
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any, Mapping
+
+
+SCHEMA_VERSION = "workload_schema_v1"
+
+PTR_DTYPE_ALLOWED = ("fp64", "fp32", "fp16", "bf16")
+PRECISION_ALLOWED = ("fp64", "fp32", "fp16", "bf16", "amp")
+
+ANT_REQUIRED = ("ring_len", "slot_dim", "ptr_dtype", "precision")
+COL_REQUIRED = ("seq_len", "synth_len", "batch_size", "ptr_update_every", "state_loop_samples")
+
+_TOP_ALLOWED = frozenset({"schema_version", "ant_spec", "colony_spec", "name", "notes"})
+_ANT_ALLOWED = frozenset(set(ANT_REQUIRED) | {"name", "notes"})
+_COL_ALLOWED = frozenset(set(COL_REQUIRED) | {"name", "notes"})
+
+
+def load_workload_spec(path: str) -> dict[str, Any]:
+    """Load a workload spec JSON file."""
+
+    pth = Path(path)
+    with pth.open("r", encoding="utf-8") as f:
+        obj = json.load(f)
+    if not isinstance(obj, dict):
+        raise ValueError("Workload spec must be a JSON object at top-level.")
+    return obj
+
+
+def _unknown_keys(obj: Mapping[str, Any], *, allowed: frozenset[str]) -> set[str]:
+    return {k for k in obj.keys() if k not in allowed}
+
+
+def _expect_dict(val: Any, *, label: str) -> Mapping[str, Any]:
+    if not isinstance(val, dict):
+        raise ValueError(f"{label} must be a JSON object.")
+    return val
+
+
+def _expect_int(val: Any, *, label: str, min_value: int) -> int:
+    if not isinstance(val, int) or isinstance(val, bool):
+        raise ValueError(f"{label} must be an integer.")
+    if val < min_value:
+        raise ValueError(f"{label} must be >= {min_value}.")
+    return val
+
+
+def _expect_enum(val: Any, *, label: str, allowed: tuple[str, ...]) -> str:
+    if not isinstance(val, str):
+        raise ValueError(f"{label} must be a string.")
+    if val not in allowed:
+        raise ValueError(f"{label} must be one of: {', '.join(allowed)}.")
+    return val
+
+
+def canonicalize_spec(spec: dict[str, Any]) -> dict[str, Any]:
+    """Validate and return canonical spec (drops non-ID fields).
+
+    Canonical output includes only:
+      {schema_version, ant_spec(required keys), colony_spec(required keys)}
+    """
+
+    bad_top = _unknown_keys(spec, allowed=_TOP_ALLOWED)
+    if bad_top:
+        raise ValueError(f"Unknown top-level key(s): {sorted(bad_top)!r}")
+
+    if spec.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(f"schema_version must be {SCHEMA_VERSION!r}.")
+
+    ant = _expect_dict(spec.get("ant_spec"), label="ant_spec")
+    col = _expect_dict(spec.get("colony_spec"), label="colony_spec")
+
+    bad_ant = _unknown_keys(ant, allowed=_ANT_ALLOWED)
+    if bad_ant:
+        raise ValueError(f"Unknown ant_spec key(s): {sorted(bad_ant)!r}")
+
+    bad_col = _unknown_keys(col, allowed=_COL_ALLOWED)
+    if bad_col:
+        raise ValueError(f"Unknown colony_spec key(s): {sorted(bad_col)!r}")
+
+    ant_canon = {
+        "ring_len": _expect_int(ant.get("ring_len"), label="ant_spec.ring_len", min_value=1),
+        "slot_dim": _expect_int(ant.get("slot_dim"), label="ant_spec.slot_dim", min_value=1),
+        "ptr_dtype": _expect_enum(ant.get("ptr_dtype"), label="ant_spec.ptr_dtype", allowed=PTR_DTYPE_ALLOWED),
+        "precision": _expect_enum(ant.get("precision"), label="ant_spec.precision", allowed=PRECISION_ALLOWED),
+    }
+
+    col_canon = {
+        "seq_len": _expect_int(col.get("seq_len"), label="colony_spec.seq_len", min_value=1),
+        "synth_len": _expect_int(col.get("synth_len"), label="colony_spec.synth_len", min_value=1),
+        "batch_size": _expect_int(col.get("batch_size"), label="colony_spec.batch_size", min_value=1),
+        "ptr_update_every": _expect_int(col.get("ptr_update_every"), label="colony_spec.ptr_update_every", min_value=1),
+        "state_loop_samples": _expect_int(
+            col.get("state_loop_samples"),
+            label="colony_spec.state_loop_samples",
+            min_value=0,
+        ),
+    }
+
+    return {"schema_version": SCHEMA_VERSION, "ant_spec": ant_canon, "colony_spec": col_canon}
+
+
+def _canonical_json(obj: Mapping[str, Any]) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def compute_workload_id(canon: Mapping[str, Any]) -> str:
+    """Compute stable workload ID from a canonical workload spec."""
+
+    payload = _canonical_json(canon).encode("utf-8")
+    digest = hashlib.sha256(payload).hexdigest()
+    return f"wl_v1_{digest[:12]}"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(add_help=True)
+    p.add_argument("spec", help="Path to workload spec JSON (workload_schema_v1)")
+    p.add_argument("--json", action="store_true", help="Print canonicalized spec + workload_id as JSON")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    try:
+        spec = load_workload_spec(args.spec)
+        canon = canonicalize_spec(spec)
+        wid = compute_workload_id(canon)
+    except Exception as exc:
+        print(f"[workload_id] error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        out = {
+            "workload_id": wid,
+            "schema_version": canon["schema_version"],
+            "ant_spec": canon["ant_spec"],
+            "colony_spec": canon["colony_spec"],
+        }
+        print(json.dumps(out, indent=2, ensure_ascii=True, sort_keys=True))
+    else:
+        print(wid)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/Golden Draft/workloads/od1_real_v1.json
+++ b/Golden Draft/workloads/od1_real_v1.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "workload_schema_v1",
+  "ant_spec": {
+    "ring_len": 8192,
+    "slot_dim": 576,
+    "ptr_dtype": "fp64",
+    "precision": "fp32"
+  },
+  "colony_spec": {
+    "seq_len": 256,
+    "synth_len": 256,
+    "batch_size": 16,
+    "ptr_update_every": 1,
+    "state_loop_samples": 0
+  }
+}
+

--- a/Golden Draft/workloads/od1_small_v1.json
+++ b/Golden Draft/workloads/od1_small_v1.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "workload_schema_v1",
+  "ant_spec": {
+    "ring_len": 2048,
+    "slot_dim": 256,
+    "ptr_dtype": "fp64",
+    "precision": "fp32"
+  },
+  "colony_spec": {
+    "seq_len": 128,
+    "synth_len": 128,
+    "batch_size": 4,
+    "ptr_update_every": 1,
+    "state_loop_samples": 0
+  }
+}
+

--- a/Golden Draft/workloads/od1_stress_v1.json
+++ b/Golden Draft/workloads/od1_stress_v1.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "workload_schema_v1",
+  "ant_spec": {
+    "ring_len": 16384,
+    "slot_dim": 768,
+    "ptr_dtype": "fp64",
+    "precision": "fp32"
+  },
+  "colony_spec": {
+    "seq_len": 256,
+    "synth_len": 256,
+    "batch_size": 16,
+    "ptr_update_every": 1,
+    "state_loop_samples": 0
+  }
+}
+

--- a/VERSION.json
+++ b/VERSION.json
@@ -1,5 +1,5 @@
 {
   "major": 2,
   "minor": 10,
-  "build": 575
+  "build": 576
 }


### PR DESCRIPTION
Adds a contract-first workload abstraction (AntSpec + ColonySpec) and a deterministic `workload_id` generator, plus 3 canonical OD1 workload templates.

Deliverables:
- `Golden Draft/docs/gpu/workload_schema_v1.md`
- `Golden Draft/tools/workload_id.py`
- `Golden Draft/workloads/od1_small_v1.json`
- `Golden Draft/workloads/od1_real_v1.json`
- `Golden Draft/workloads/od1_stress_v1.json`
- `Golden Draft/tests/test_workload_id.py`
- `VERSION.json` (BUILD 575 -> 576)

Verification:
- `python -m unittest discover -s "Golden Draft/tests" -v`
- `python -m compileall "Golden Code" "Golden Draft"`
- `python "Golden Draft/tools/workload_id.py" "Golden Draft/workloads/od1_real_v1.json"`

Notes:
- No GPU runs executed here. VRA-32 / future sweep scripts should consume these templates + IDs.