### PR TITLE
chore(nightmode): import supervisor + wake scripts

### DIFF
--- a/Golden Draft/tools/_scratch/check_latest_vraxion_log.py
+++ b/Golden Draft/tools/_scratch/check_latest_vraxion_log.py
@@ -1,0 +1,42 @@
+"""Print the most recently modified bench_vault/benchmarks/**/vraxion.log.
+
+Used by PLANLAB to prove "time-to-visible-output" quickly without relying on
+PowerShell variables/quoting.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--repo-root", type=str, default=r"S:\AI\work\VRAXION_DEV")
+    p.add_argument("--tail", type=int, default=3)
+    args = p.parse_args()
+
+    repo_root = Path(args.repo_root)
+    bench_root = repo_root / "bench_vault" / "benchmarks"
+    logs = list(bench_root.rglob("vraxion.log"))
+    if not logs:
+        print(f"[latest_log] none found under {bench_root}")
+        return 2
+
+    logs.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    log_path = logs[0]
+    try:
+        lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except Exception:
+        lines = []
+
+    print(f"[latest_log] {log_path}")
+    if lines:
+        for ln in lines[-int(max(1, args.tail)) :]:
+            print(ln)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/Golden Draft/tools/_scratch/launch_results_dashboard.py
+++ b/Golden Draft/tools/_scratch/launch_results_dashboard.py
@@ -1,0 +1,98 @@
+"""Launch the Streamlit results dashboard in a detached process.
+
+Why this exists:
+- Running Streamlit directly from the CLI tool session can terminate the
+  server when the session ends.
+- PowerShell one-liners are brittle in this environment (quoting / `$`).
+- We want a single, reliable command that launches the dashboard and keeps
+  it alive, with logs written to bench_vault/_tmp.
+
+Usage:
+  python "Golden Draft/tools/_scratch/launch_results_dashboard.py" --port 8520
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def _is_port_open(port: int) -> bool:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.settimeout(0.2)
+        return s.connect_ex(("127.0.0.1", int(port))) == 0
+    finally:
+        try:
+            s.close()
+        except Exception:
+            pass
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--port", type=int, default=8520)
+    args = p.parse_args(argv)
+
+    # .../Golden Draft/tools/_scratch/ -> parents[0]=_scratch, [1]=tools,
+    # [2]=Golden Draft, [3]=repo root
+    repo_root = Path(__file__).resolve().parents[3]
+    app_path = repo_root / "Golden Draft" / "tools" / "results_dashboard.py"
+    if not app_path.exists():
+        raise SystemExit(f"results_dashboard.py not found: {app_path}")
+
+    port = int(args.port)
+    if _is_port_open(port):
+        print(f"[dashboard] already listening on port {port}")
+        print(f"[dashboard] open: http://localhost:{port}")
+        return 0
+
+    log_dir = repo_root / "bench_vault" / "_tmp"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    ts = time.strftime("%Y%m%d_%H%M%S")
+    log_path = log_dir / f"results_dashboard_{port}_{ts}.log"
+
+    # Detach on Windows so the dashboard survives the parent session.
+    creationflags = 0
+    if os.name == "nt":
+        creationflags = int(getattr(subprocess, "DETACHED_PROCESS", 0)) | int(
+            getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+        )
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "streamlit",
+        "run",
+        str(app_path),
+        "--server.port",
+        str(port),
+        "--server.headless",
+        "true",
+        "--browser.gatherUsageStats",
+        "false",
+    ]
+
+    with log_path.open("w", encoding="utf-8") as lf:
+        proc = subprocess.Popen(
+            cmd,
+            cwd=str(repo_root),
+            stdout=lf,
+            stderr=subprocess.STDOUT,
+            creationflags=creationflags,
+        )
+
+    print(f"[dashboard] launched pid={proc.pid} port={port}")
+    print(f"[dashboard] log: {log_path}")
+    print(f"[dashboard] open: http://localhost:{port}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/Golden Draft/tools/_scratch/print_report_summary.py
+++ b/Golden Draft/tools/_scratch/print_report_summary.py
@@ -1,0 +1,71 @@
+"""Print a concise summary from a VRAXION run_root/report.json (ASCII-only)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+def _get(d: Dict[str, Any], path: str) -> Any:
+    cur: Any = d
+    for part in path.split("."):
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(part)
+    return cur
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--run-root", type=str, required=True)
+    args = p.parse_args()
+
+    run_root = Path(args.run_root)
+    report_path = run_root / "report.json"
+    if not report_path.exists():
+        raise SystemExit(f"missing report.json: {report_path}")
+
+    r = json.loads(report_path.read_text(encoding="utf-8"))
+
+    settings = r.get("settings") or {}
+    prism = r.get("prismion_bank") or {}
+    train = r.get("train") or {}
+    ev = r.get("eval") or {}
+
+    val_range = int(settings.get("val_range") or 0)
+    chance = (1.0 / float(val_range)) if val_range else None
+    eval_acc = ev.get("eval_acc")
+    acc_delta = (float(eval_acc) - float(chance)) if (chance is not None and eval_acc is not None) else None
+
+    print(f"run_root={run_root}")
+    print(f"model={settings.get('model')} device={settings.get('device')} seed={settings.get('seed')}")
+    print(
+        "N={n} out_dim={od} mode={mode} shared={sh} ring_len={rl} slot_dim={sd} seq_len={sl}".format(
+            n=prism.get("n"),
+            od=prism.get("out_dim"),
+            mode=prism.get("mode"),
+            sh=prism.get("shared"),
+            rl=settings.get("ring_len"),
+            sd=settings.get("slot_dim"),
+            sl=settings.get("seq_len"),
+        )
+    )
+    print(f"steps={train.get('steps')} loss_slope={train.get('loss_slope')}")
+    print(
+        "eval_acc={acc} eval_loss={loss} eval_n={n} val_range={vr} chance={ch} acc_delta={ad}".format(
+            acc=ev.get("eval_acc"),
+            loss=ev.get("eval_loss"),
+            n=ev.get("eval_n"),
+            vr=val_range,
+            ch=chance,
+            ad=acc_delta,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/Golden Draft/tools/_scratch/results_audit.py
+++ b/Golden Draft/tools/_scratch/results_audit.py
@@ -1,0 +1,105 @@
+"""Audit bench_vault/results/results_master.csv for misleading / low-confidence rows.
+
+This exists to avoid "smoke" runs (tiny steps or tiny eval_n) showing up as
+"best" in dashboards/frontiers and wasting time.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pandas as pd
+
+
+REPO_ROOT = Path(r"S:\AI\work\VRAXION_DEV")
+MASTER = REPO_ROOT / "bench_vault" / "results" / "results_master.csv"
+
+
+def _ci95(p: float, n: int) -> float:
+    # Binomial normal approx is fine for quick gating.
+    if n <= 0:
+        return float("nan")
+    p = max(0.0, min(1.0, float(p)))
+    se = math.sqrt(max(0.0, p * (1.0 - p) / float(n)))
+    return 1.96 * se
+
+
+def main() -> int:
+    if not MASTER.exists():
+        raise SystemExit(f"missing: {MASTER}")
+
+    df = pd.read_csv(MASTER)
+    print(f"[audit] master={MASTER} rows={len(df)} cols={len(df.columns)}")
+
+    # Basic missingness
+    for col in ("eval_acc", "eval_n", "steps", "val_range", "seq_len", "run_root"):
+        if col not in df.columns:
+            print(f"[audit] WARNING missing column: {col}")
+
+    # Compute chance + CI + delta where possible.
+    df["val_range_num"] = pd.to_numeric(df.get("val_range"), errors="coerce")
+    df["chance_acc"] = 1.0 / df["val_range_num"]
+    df["eval_acc_num"] = pd.to_numeric(df.get("eval_acc"), errors="coerce")
+    df["eval_n_num"] = pd.to_numeric(df.get("eval_n"), errors="coerce")
+    df["steps_num"] = pd.to_numeric(df.get("steps"), errors="coerce")
+    df["acc_delta"] = df["eval_acc_num"] - df["chance_acc"]
+    df["ci95"] = [
+        _ci95(p, int(n)) if pd.notna(p) and pd.notna(n) else float("nan")
+        for p, n in zip(df["eval_acc_num"].tolist(), df["eval_n_num"].tolist())
+    ]
+
+    # Quick flags for misleading points.
+    df["flag_tiny_steps"] = df["steps_num"].fillna(-1) < 10
+    df["flag_tiny_eval"] = df["eval_n_num"].fillna(-1) < 256
+    df["flag_missing_steps"] = df["steps_num"].isna()
+    df["flag_missing_eval"] = df["eval_acc_num"].isna() | df["eval_n_num"].isna()
+
+    def _cnt(name: str, mask: pd.Series) -> None:
+        print(f"[audit] {name} = {int(mask.sum())}")
+
+    _cnt("missing_eval", df["flag_missing_eval"])
+    _cnt("missing_steps", df["flag_missing_steps"])
+    _cnt("tiny_steps(<10)", df["flag_tiny_steps"])
+    _cnt("tiny_eval_n(<256)", df["flag_tiny_eval"])
+
+    # Show top eval_acc rows (this is where misleading smoke runs surface).
+    view = df.dropna(subset=["eval_acc_num"]).copy().sort_values("eval_acc_num", ascending=False).head(20)
+    cols = [
+        "eval_acc_num",
+        "ci95",
+        "eval_n_num",
+        "chance_acc",
+        "acc_delta",
+        "steps_num",
+        "seq_len",
+        "val_range",
+        "prismn_n",
+        "prismn_out_dim",
+        "run_root",
+    ]
+    cols = [c for c in cols if c in view.columns]
+    print("\n[audit] TOP eval_acc (watch for tiny steps/eval_n):")
+    print(view[cols].to_string(index=False))
+
+    # List the most misleading: high eval_acc but tiny eval_n or tiny steps.
+    mis = df[
+        (df["eval_acc_num"].notna())
+        & (df["eval_acc_num"] >= 0.10)
+        & (df["flag_tiny_steps"] | df["flag_tiny_eval"])
+    ].copy()
+    if len(mis) > 0:
+        mis = mis.sort_values(["eval_acc_num", "eval_n_num"], ascending=[False, True]).head(25)
+        cols2 = ["eval_acc_num", "ci95", "eval_n_num", "steps_num", "seq_len", "run_root"]
+        cols2 = [c for c in cols2 if c in mis.columns]
+        print("\n[audit] MISLEADING high-acc smoke rows (should be filtered from leaderboards):")
+        print(mis[cols2].to_string(index=False))
+    else:
+        print("\n[audit] No high-acc smoke rows detected (good).")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/Golden Draft/tools/_scratch/run_transistor_sweep.py
+++ b/Golden Draft/tools/_scratch/run_transistor_sweep.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python
+"""
+Deterministic sweep runner for the transistor-style NAND suite (logic_nand).
+
+Why a script:
+- Avoid brittle inline PowerShell / quoting.
+- Run a small matrix of configs and print a compact PASS/FAIL table.
+
+This script only launches short runs via the existing boot runner:
+Golden Draft/benchmarks/boot_synth_assoc_byte/run_boot_synth_assoc_byte.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+
+REPO_ROOT = Path(r"S:\AI\work\VRAXION_DEV")
+BOOT_DIR = REPO_ROOT / "Golden Draft" / "benchmarks" / "boot_synth_assoc_byte"
+BOOT_PY = BOOT_DIR / "run_boot_synth_assoc_byte.py"
+BENCH_ROOT = REPO_ROOT / "bench_vault" / "benchmarks"
+
+
+@dataclass(frozen=True)
+class RunCfg:
+    n: int
+    out_dim: int
+    slot_dim: int
+    ring_len: int
+    seq_len: int
+    mode: str
+    shared: int
+    seed: int
+    steps: int
+    eval_samples: int
+    max_samples: int
+    lr: float
+
+    def tag(self) -> str:
+        return (
+            f"logic_nand_n{self.n}_od{self.out_dim}_sd{self.slot_dim}"
+            f"_rl{self.ring_len}_sl{self.seq_len}_m{self.mode}_sh{self.shared}"
+            f"_seed{self.seed}_st{self.steps}_en{self.eval_samples}"
+        )
+
+
+def _run(cmd: List[str], cwd: Path) -> None:
+    # Keep output streaming to console for visibility.
+    p = subprocess.Popen(cmd, cwd=str(cwd), env=os.environ.copy())
+    rc = p.wait()
+    if rc != 0:
+        raise RuntimeError(f"command failed rc={rc}: {' '.join(cmd)}")
+
+
+def _latest_run_dir(tag: str) -> Path:
+    # The boot runner may append extra suffixes to the tag directory
+    # (e.g. "_prismion_hallway_bank_n1_mean"). Match by prefix.
+    candidates = [p for p in BENCH_ROOT.glob(f"{tag}*") if p.is_dir()]
+    if not candidates:
+        raise FileNotFoundError(str(BENCH_ROOT / tag))
+    candidates.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    base = candidates[0]
+
+    # run_root naming is timestamped; pick newest directory.
+    subdirs = [p for p in base.iterdir() if p.is_dir()]
+    if not subdirs:
+        raise FileNotFoundError(f"no run dirs under: {base}")
+    subdirs.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    return subdirs[0]
+
+
+def _read_json(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _summarize_report(run_root: Path) -> Dict[str, Any]:
+    rep_path = run_root / "report.json"
+    if not rep_path.exists():
+        raise FileNotFoundError(str(rep_path))
+    rep = _read_json(rep_path)
+    eval_sum = rep.get("eval") or {}
+    extra = rep.get("eval_extra") or {}
+    out: Dict[str, Any] = {
+        "run_root": str(run_root),
+        "checkpoint_step": int(rep.get("train", {}).get("steps") or rep.get("checkpoint_step") or 0),
+        # Report schema uses eval_acc/eval_loss keys.
+        "eval_acc": float(eval_sum.get("eval_acc") or 0.0),
+        "eval_loss": float(eval_sum.get("eval_loss") or 0.0),
+        "pass_strict": bool(extra.get("pass_strict") or False),
+        "min_case_acc": float(extra.get("min_case_acc") or 0.0),
+        "min_p_true": float(extra.get("min_p_true") or 0.0),
+        "min_margin": float(extra.get("min_margin") or 0.0),
+    }
+    return out
+
+
+def _format_row(cfg: RunCfg, s: Dict[str, Any]) -> str:
+    # Small, stable, grep-friendly line.
+    status = "PASS" if s["pass_strict"] else "FAIL"
+    return (
+        f"{status} "
+        f"n={cfg.n} od={cfg.out_dim} sd={cfg.slot_dim} rl={cfg.ring_len} sl={cfg.seq_len} "
+        f"mode={cfg.mode} sh={cfg.shared} seed={cfg.seed} "
+        f"step={s['checkpoint_step']} acc={s['eval_acc']:.4f} "
+        f"minP={s['min_p_true']:.3f} minM={s['min_margin']:.3f} "
+        f"run_root={s['run_root']}"
+    )
+
+
+def _build_cmd(cfg: RunCfg) -> List[str]:
+    return [
+        sys.executable,
+        "-u",
+        str(BOOT_PY),
+        "--synth-mode",
+        "logic_nand",
+        "--model",
+        "prismion_hallway_bank",
+        "--prismn-n",
+        str(cfg.n),
+        "--prismn-mode",
+        cfg.mode,
+        "--prismn-shared",
+        str(cfg.shared),
+        "--prismn-out-dim",
+        str(cfg.out_dim),
+        "--slot-dim",
+        str(cfg.slot_dim),
+        "--ring-len",
+        str(cfg.ring_len),
+        "--seq-len",
+        str(cfg.seq_len),
+        "--steps",
+        str(cfg.steps),
+        "--max-samples",
+        str(cfg.max_samples),
+        "--eval-samples",
+        str(cfg.eval_samples),
+        "--seed",
+        str(cfg.seed),
+        "--lr",
+        str(cfg.lr),
+        "--device",
+        "cpu",
+        "--eval-disjoint",
+        "--tag",
+        cfg.tag(),
+    ]
+
+
+def _parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--quick", action="store_true", help="Run only the N=1 slot_dim sweep (4→1).")
+    p.add_argument("--seed", type=int, default=126)
+    p.add_argument(
+        "--slot-dims",
+        type=str,
+        default="",
+        help="Comma list override for slot_dim sweep (e.g. '1,2,3'). Default is '4,3,2,1'.",
+    )
+    p.add_argument("--steps", type=int, default=200)
+    p.add_argument("--eval-samples", type=int, default=512)
+    p.add_argument("--max-samples", type=int, default=512)
+    p.add_argument("--ring-len", type=int, default=7)
+    p.add_argument("--seq-len", type=int, default=8)
+    p.add_argument("--lr", type=float, default=5e-3)
+    return p.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = _parse_args(argv)
+
+    if not BOOT_PY.exists():
+        raise SystemExit(f"boot runner not found: {BOOT_PY}")
+    if not BENCH_ROOT.exists():
+        raise SystemExit(f"bench root not found: {BENCH_ROOT}")
+
+    # Sweep 1: N=1, out_dim=1, slot_dim down to 1.
+    if str(args.slot_dims).strip():
+        slot_dims = [int(x) for x in str(args.slot_dims).split(",") if x.strip()]
+    else:
+        slot_dims = [4, 3, 2, 1]
+
+    cfgs: List[RunCfg] = []
+    for sd in slot_dims:
+        cfgs.append(
+            RunCfg(
+                n=1,
+                out_dim=1,
+                slot_dim=sd,
+                ring_len=int(args.ring_len),
+                seq_len=int(args.seq_len),
+                mode="mean",
+                shared=1,
+                seed=int(args.seed),
+                steps=int(args.steps),
+                eval_samples=int(args.eval_samples),
+                max_samples=int(args.max_samples),
+                lr=float(args.lr),
+            )
+        )
+
+    # Sweep 2: small “more ants / smaller ants” grid (kept tiny on purpose).
+    if not args.quick:
+        for n in (2, 4, 8):
+            for sd in (1, 2):
+                cfgs.append(
+                    RunCfg(
+                        n=n,
+                        out_dim=1,
+                        slot_dim=sd,
+                        ring_len=int(args.ring_len),
+                        seq_len=int(args.seq_len),
+                        mode="mosaic",
+                        shared=1,
+                        seed=int(args.seed),
+                        steps=int(args.steps),
+                        eval_samples=int(args.eval_samples),
+                        max_samples=int(args.max_samples),
+                        lr=float(args.lr),
+                    )
+                )
+
+    print(f"[sweep] count={len(cfgs)} bench_root={BENCH_ROOT}")
+    t0 = time.time()
+    results: List[Tuple[RunCfg, Dict[str, Any]]] = []
+    for i, cfg in enumerate(cfgs, start=1):
+        print(f"[sweep] ({i}/{len(cfgs)}) START {cfg.tag()}")
+        cmd = _build_cmd(cfg)
+        _run(cmd, cwd=BOOT_DIR)
+        run_root = _latest_run_dir(cfg.tag())
+        s = _summarize_report(run_root)
+        results.append((cfg, s))
+        print(_format_row(cfg, s))
+
+    dt = time.time() - t0
+    print(f"[sweep] done_s={dt:.1f}")
+
+    # Compact PASS frontier by (slot_dim, n).
+    print("[frontier] passing configs (sorted by cost proxy: n*slot_dim):")
+    passing = [(cfg, s) for (cfg, s) in results if s["pass_strict"]]
+    passing.sort(key=lambda cs: (cs[0].n * cs[0].slot_dim, cs[0].slot_dim, cs[0].n))
+    for cfg, s in passing:
+        cost = cfg.n * cfg.slot_dim
+        print(f"PASS cost={cost:3d} n={cfg.n} sd={cfg.slot_dim} od={cfg.out_dim} mode={cfg.mode} run_root={s['run_root']}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Golden Draft/tools/auto_wake_protocol.md
+++ b/Golden Draft/tools/auto_wake_protocol.md
@@ -1,0 +1,66 @@
+# VRAXION Loopback Protocol (Supervisor + Ghost Hand)
+
+Goal: keep long VRAXION runs alive (and restartable) even when the Codex chat turn
+ends, and "wake" the chat only when something meaningful happens.
+
+This uses two pieces:
+
+1) `Golden Draft/tools/vraxion_lab_supervisor.py`
+2) `Golden Draft/tools/ghost_wake.ps1`
+
+## 1) One-time setup (recommended)
+
+In the PowerShell window where you run Codex/VRAXION, set a stable window title:
+
+```powershell
+$host.UI.RawUI.WindowTitle = "VRAXION_CLI"
+```
+
+## 2) Start Ghost Hand (separate window)
+
+Run this in a separate PowerShell window (keep it open):
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File "S:\AI\work\VRAXION_DEV\Golden Draft\tools\ghost_wake.ps1"
+```
+
+It watches for:
+
+`S:\AI\work\VRAXION_DEV\bench_vault\wake_trigger.json`
+
+## 3) Start a supervised long run
+
+Example: run the repulsion sweep under a supervisor (auto-restart on crash):
+
+```powershell
+Set-Location "S:\AI\work\VRAXION_DEV"
+python -u "Golden Draft\tools\vraxion_lab_supervisor.py" `
+  --job-name "assoc_repulsion_sweep" `
+  --wake-window-title "VRAXION_CLI" `
+  --wake-after-s 720 `
+  --watchdog-no-output-s 120 `
+  --max-restarts 20 `
+  -- `
+  python -u "Golden Draft\tools\sweep_assoc_repulsion.py"
+```
+
+When the run finishes (or crashes), the supervisor writes a wake trigger and the
+Ghost Hand will type a memo + press Enter into the VRAXION_CLI window.
+
+## Trigger format
+
+The supervisor writes a JSON file like:
+
+```json
+{
+  "version": 1,
+  "wake_after_s": 720,
+  "memo": "[vraxion_lab_supervisor] DONE ...",
+  "reason": "done",
+  "job_root": "S:\\AI\\work\\VRAXION_DEV\\bench_vault\\jobs\\...",
+  "window_title": "VRAXION_CLI"
+}
+```
+
+Ghost Hand moves it to `wake_trigger.processed_*.json` after sending it.
+

--- a/Golden Draft/tools/datapoint_2seed_runner.py
+++ b/Golden Draft/tools/datapoint_2seed_runner.py
@@ -1,0 +1,508 @@
+"""Run a 2-seed benchmark datapoint (same config) and ingest/gate results.
+
+Design goals:
+- Single command to produce a *rankable* datapoint pair (two seeds).
+- No inline PowerShell logic; everything is driven from Python.
+- Auto-launch the Streamlit results dashboard (detached) so the user can watch.
+- Optional microprobe (default 20 steps) to estimate ETA before committing.
+
+This is intended to be the lowest-friction "datapoint miner" for the
+VRAXION multi-axis frontier (N, out_dim, slot_dim, ring_len, etc.).
+
+Usage (example):
+  python "Golden Draft/tools/datapoint_2seed_runner.py" ^
+    --tag dev32_sd4_rl64_od1 ^
+    --seeds 111,222 ^
+    --steps 1000 ^
+    --hard-eval-samples 4096
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+
+def _repo_root() -> Path:
+    # .../Golden Draft/tools/datapoint_2seed_runner.py -> repo root is parents[2]
+    return Path(__file__).resolve().parents[2]
+
+
+def _parse_seeds(s: str) -> List[int]:
+    out: List[int] = []
+    for part in (s or "").split(","):
+        part = part.strip()
+        if not part:
+            continue
+        out.append(int(part))
+    if not out:
+        raise SystemExit("no seeds provided (use --seeds 111,222)")
+    return out
+
+
+def _ensure_dashboard(repo_root: Path, port: int) -> None:
+    launcher = repo_root / "Golden Draft" / "tools" / "_scratch" / "launch_results_dashboard.py"
+    if not launcher.exists():
+        raise SystemExit(f"dashboard launcher missing: {launcher}")
+    subprocess.run(
+        [sys.executable, str(launcher), "--port", str(int(port))],
+        cwd=str(repo_root),
+        check=True,
+    )
+
+
+def _ci95(p: float, n: int) -> float:
+    # Normal approximation (good enough for PASS/FAIL gating at our eval_n).
+    if n <= 0:
+        return float("nan")
+    import math
+
+    p = max(0.0, min(1.0, float(p)))
+    se = math.sqrt(max(0.0, p * (1.0 - p) / float(n)))
+    return 1.96 * se
+
+
+def _read_report(run_root: Path) -> dict:
+    import json
+
+    report_path = run_root / "report.json"
+    if not report_path.exists():
+        raise RuntimeError(f"missing report.json: {report_path}")
+    return json.loads(report_path.read_text(encoding="utf-8"))
+
+
+def _gate_row(*, run_root: Path) -> dict:
+    r = _read_report(run_root)
+    settings = r.get("settings") or {}
+    ev = r.get("eval") or {}
+    train = r.get("train") or {}
+
+    val_range = int(settings.get("val_range") or 0)
+    chance = (1.0 / float(val_range)) if val_range else float("nan")
+    acc = float(ev.get("eval_acc") or 0.0)
+    n = int(ev.get("eval_n") or 0)
+    ci = _ci95(acc, n)
+    lower = acc - ci
+    pass_gate = bool(val_range) and bool(n) and (lower > chance)
+
+    return {
+        "seed": settings.get("seed"),
+        "steps": int(train.get("steps") or 0),
+        "val_range": val_range,
+        "chance": chance,
+        "eval_acc": acc,
+        "eval_n": n,
+        "ci95": ci,
+        "lower95": lower,
+        "acc_delta": acc - chance if val_range else float("nan"),
+        "pass": pass_gate,
+    }
+
+
+def _postmortem_eval(
+    *,
+    repo_root: Path,
+    run_root: Path,
+    checkpoint: Optional[Path],
+    eval_samples: int,
+    batch_size: int,
+    device: str,
+    prismn_id_scale: float,
+) -> None:
+    """Overwrite run_root/report.json with a high-precision eval from the latest checkpoint."""
+    tool = repo_root / "Golden Draft" / "tools" / "eval_ckpt_assoc_byte.py"
+    if not tool.exists():
+        raise SystemExit(f"missing postmortem eval tool: {tool}")
+
+    if checkpoint is None or not checkpoint.exists():
+        print(f"[postmortem] skip (no checkpoint): {run_root}")
+        return
+
+    cmd = [
+        sys.executable,
+        str(tool),
+        "--run-root",
+        str(run_root),
+        "--checkpoint",
+        str(checkpoint),
+        "--eval-samples",
+        str(int(eval_samples)),
+        "--batch-size",
+        str(int(batch_size)),
+        "--device",
+        str(device),
+        "--prismn-id-scale",
+        str(float(prismn_id_scale)),
+    ]
+
+    subprocess.run(
+        cmd,
+        cwd=str(repo_root / "Golden Draft"),
+        check=True,
+    )
+
+
+def _find_checkpoint(run_root: Path) -> Optional[Path]:
+    # Prefer common stable names; fall back to latest step checkpoint.
+    for name in ("checkpoint_last_good.pt", "checkpoint.pt"):
+        p = run_root / name
+        if p.exists():
+            return p
+
+    ck_dir = run_root / "checkpoints"
+    if ck_dir.exists():
+        cands = list(ck_dir.glob("checkpoint_step_*.pt"))
+        if cands:
+            cands.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+            return cands[0]
+    return None
+
+
+def _run_boot(
+    *,
+    repo_root: Path,
+    tag: str,
+    seed: int,
+    steps: int,
+    seq_len: int,
+    batch_size: int,
+    max_samples: int,
+    eval_samples: int,
+    ring_len: int,
+    slot_dim: int,
+    device: str,
+    lr: float,
+    model: str,
+    prismn_n: int,
+    prismn_mode: str,
+    prismn_shared: int,
+    prismn_out_dim: int,
+    prismn_id_scale: float,
+    synth_mode: str,
+    keys: int,
+    pairs: int,
+    val_range: int,
+    assoc_unique_keys: bool,
+    assoc_mq_dup: int,
+    assoc_mq_grouped: int,
+    eval_disjoint: bool,
+    eval_ptr_deterministic: bool,
+    abort_after: int,
+    abort_acc: float,
+) -> Tuple[Path, str]:
+    boot = repo_root / "Golden Draft" / "benchmarks" / "boot_synth_assoc_byte" / "run_boot_synth_assoc_byte.py"
+    if not boot.exists():
+        raise SystemExit(f"boot runner missing: {boot}")
+
+    cmd = [
+        sys.executable,
+        "-u",
+        str(boot),
+        "--tag",
+        tag,
+        "--seed",
+        str(int(seed)),
+        "--steps",
+        str(int(steps)),
+        "--seq-len",
+        str(int(seq_len)),
+        "--batch-size",
+        str(int(batch_size)),
+        "--max-samples",
+        str(int(max_samples)),
+        "--eval-samples",
+        str(int(eval_samples)),
+        "--ring-len",
+        str(int(ring_len)),
+        "--slot-dim",
+        str(int(slot_dim)),
+        "--device",
+        str(device),
+        "--lr",
+        str(float(lr)),
+        "--model",
+        str(model),
+        "--prismn-n",
+        str(int(prismn_n)),
+        "--prismn-mode",
+        str(prismn_mode),
+        "--prismn-shared",
+        str(int(prismn_shared)),
+        "--prismn-out-dim",
+        str(int(prismn_out_dim)),
+        "--prismn-id-scale",
+        str(float(prismn_id_scale)),
+        "--synth-mode",
+        str(synth_mode),
+        "--keys",
+        str(int(keys)),
+        "--pairs",
+        str(int(pairs)),
+        "--val-range",
+        str(int(val_range)),
+        "--assoc-mq-dup",
+        str(int(assoc_mq_dup)),
+        "--assoc-mq-grouped",
+        str(int(assoc_mq_grouped)),
+    ]
+
+    if assoc_unique_keys:
+        cmd.append("--assoc-unique-keys")
+    if eval_disjoint:
+        cmd.append("--eval-disjoint")
+    if eval_ptr_deterministic:
+        cmd.append("--eval-ptr-deterministic")
+    if int(abort_after) > 0:
+        cmd.extend(["--abort-after", str(int(abort_after)), "--abort-acc", str(float(abort_acc))])
+
+    env = os.environ.copy()
+    env["PYTHONUNBUFFERED"] = "1"
+
+    p = subprocess.run(cmd, cwd=str(repo_root), env=env, text=True, capture_output=True)
+    out = (p.stdout or "") + "\n" + (p.stderr or "")
+    if p.returncode != 0:
+        raise RuntimeError(f"boot runner failed rc={p.returncode}\n{out[-4000:]}")
+
+    # Parse run_root from the runner log line:
+    #   [bench] report saved: S:\...\report.json
+    m = re.search(r"\[bench\]\s+report saved:\s+(?P<path>.+report\.json)\s*$", out, flags=re.M)
+    if not m:
+        raise RuntimeError(f"Could not locate report.json path in runner output.\n{out[-4000:]}")
+    report_path = Path(m.group("path").strip()).resolve()
+    run_root = report_path.parent
+    return run_root, out
+
+
+def _estimate_sec_per_step(run_root: Path, steps: int) -> Optional[float]:
+    log_path = run_root / "vraxion.log"
+    if not log_path.exists():
+        return None
+    # Example line:
+    # [..] step 0020/0500 | loss ... | t=12.3s | ...
+    txt = log_path.read_text(encoding="utf-8", errors="replace")
+    m = re.search(r"step\s+\d+/\d+\s+\|\s+loss\s+[\d\.]+\s+\|\s+t=(?P<t>[\d\.]+)s", txt)
+    if not m:
+        return None
+    try:
+        t_s = float(m.group("t"))
+        if steps <= 0:
+            return None
+        return t_s / float(steps)
+    except Exception:
+        return None
+
+
+def _ingest_and_gate(repo_root: Path) -> None:
+    # Ingest into results_master.csv, then apply professor gate into derived/ tables.
+    ingest = repo_root / "Golden Draft" / "tools" / "results_ingest.py"
+    gate = repo_root / "Golden Draft" / "tools" / "results_professor_gate.py"
+    if not ingest.exists():
+        raise SystemExit(f"missing ingest tool: {ingest}")
+    if not gate.exists():
+        raise SystemExit(f"missing professor gate tool: {gate}")
+    subprocess.run([sys.executable, str(ingest)], cwd=str(repo_root), check=True)
+    subprocess.run([sys.executable, str(gate)], cwd=str(repo_root), check=True)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--tag", type=str, default="dev32_sd4_rl64_od1")
+    p.add_argument("--seeds", type=str, default="111,222")
+    # Hard cap: fixed max length (never extend).
+    p.add_argument("--steps", type=int, default=1000)
+    p.add_argument("--seq-len", type=int, default=128)
+    p.add_argument("--batch-size", type=int, default=32)
+    p.add_argument("--max-samples", type=int, default=4096)
+    # Training-time eval sample count (used for the soft-cap check + end-of-run smoke).
+    p.add_argument("--eval-samples", type=int, default=512)
+    # Postmortem (hard) eval sample count used for PASS/FAIL gating.
+    p.add_argument("--hard-eval-samples", type=int, default=4096)
+    p.add_argument("--ring-len", type=int, default=64)
+    p.add_argument("--slot-dim", type=int, default=4)
+    p.add_argument("--device", type=str, default="cpu", choices=["cpu", "cuda"])
+    p.add_argument("--lr", type=float, default=1e-3)
+    p.add_argument("--model", type=str, default="prismion_hallway_bank")
+    p.add_argument("--prismn-n", type=int, default=32)
+    p.add_argument("--prismn-mode", type=str, default="mosaic", choices=["mean", "mosaic", "orb_sum"])
+    p.add_argument("--prismn-shared", type=int, default=1, choices=[0, 1])
+    p.add_argument("--prismn-out-dim", type=int, default=1)
+    p.add_argument("--prismn-id-scale", type=float, default=0.02)
+    p.add_argument("--synth-mode", type=str, default="assoc_byte", choices=["assoc_byte", "assoc_clean", "assoc_mix", "logic_nand"])
+    p.add_argument("--keys", type=int, default=64)
+    p.add_argument("--pairs", type=int, default=4)
+    p.add_argument("--val-range", type=int, default=16)
+    p.add_argument("--assoc-unique-keys", action="store_true", default=True)
+    p.add_argument("--assoc-mq-dup", type=int, default=4)
+    p.add_argument("--assoc-mq-grouped", type=int, default=1, choices=[0, 1])
+    p.add_argument("--eval-disjoint", action="store_true", default=True)
+    p.add_argument("--eval-ptr-deterministic", action="store_true", default=True)
+    # Soft cap: abort early ONLY if clearly dead (time saver, not a ranking gate).
+    p.add_argument("--soft-cap-steps", type=int, default=200)
+    p.add_argument(
+        "--soft-abort-margin",
+        type=float,
+        default=0.01,
+        help="Abort if eval_acc < (chance - margin) at soft-cap.",
+    )
+    p.add_argument("--dashboard-port", type=int, default=8520)
+    # Optional ETA probe; disabled by default for datapoint mining.
+    p.add_argument("--microprobe-steps", type=int, default=0)
+    p.add_argument("--microprobe-eval-samples", type=int, default=0)
+    args = p.parse_args(argv)
+
+    repo_root = _repo_root()
+
+    # Always start the dashboard so the user can monitor live.
+    _ensure_dashboard(repo_root, int(args.dashboard_port))
+
+    seeds = _parse_seeds(str(args.seeds))
+    if len(seeds) < 2:
+        raise SystemExit("need at least 2 seeds (e.g., --seeds 111,222)")
+    seeds2 = seeds[:2]
+
+    # Microprobe (ETA guard). Optional; disabled by default for datapoint mining.
+    if int(args.microprobe_steps) > 0 and int(args.microprobe_eval_samples) > 0:
+        probe_tag = f"zprobe_{args.tag}_seed{seeds2[0]}"
+        t0 = time.time()
+        probe_root, _ = _run_boot(
+            repo_root=repo_root,
+            tag=probe_tag,
+            seed=int(seeds2[0]),
+            steps=int(args.microprobe_steps),
+            seq_len=int(args.seq_len),
+            batch_size=int(args.batch_size),
+            max_samples=int(max(args.max_samples, args.microprobe_eval_samples)),
+            eval_samples=int(args.microprobe_eval_samples),
+            ring_len=int(args.ring_len),
+            slot_dim=int(args.slot_dim),
+            device=str(args.device),
+            lr=float(args.lr),
+            model=str(args.model),
+            prismn_n=int(args.prismn_n),
+            prismn_mode=str(args.prismn_mode),
+            prismn_shared=int(args.prismn_shared),
+            prismn_out_dim=int(args.prismn_out_dim),
+            prismn_id_scale=float(args.prismn_id_scale),
+            synth_mode=str(args.synth_mode),
+            keys=int(args.keys),
+            pairs=int(args.pairs),
+            val_range=int(args.val_range),
+            assoc_unique_keys=bool(args.assoc_unique_keys),
+            assoc_mq_dup=int(args.assoc_mq_dup),
+            assoc_mq_grouped=int(args.assoc_mq_grouped),
+            eval_disjoint=bool(args.eval_disjoint),
+            eval_ptr_deterministic=bool(args.eval_ptr_deterministic),
+            abort_after=0,
+            abort_acc=0.0,
+        )
+        wall = time.time() - t0
+        sps = _estimate_sec_per_step(probe_root, int(args.microprobe_steps))
+        if sps is not None:
+            eta_train_one = sps * float(args.steps)
+            # crude eval scaling estimate from probe wall time minus training time
+            eta_eval_probe = max(0.0, wall - (sps * float(args.microprobe_steps)))
+            eta_eval_one = eta_eval_probe * (float(args.eval_samples) / float(args.microprobe_eval_samples))
+            eta_one = eta_train_one + eta_eval_one
+            eta_two = 2.0 * eta_one
+            print(f"[microprobe] run_root={probe_root}")
+            # ASCII-only output (Windows console encodings vary).
+            print(f"[microprobe] sec_per_step~{sps:.3f} wall~{wall:.1f}s")
+            print(
+                f"[microprobe] ETA per seed~{eta_one/60.0:.1f} min "
+                f"(train~{eta_train_one/60.0:.1f}, eval~{eta_eval_one/60.0:.1f})"
+            )
+            print(f"[microprobe] ETA two seeds~{eta_two/60.0:.1f} min")
+        else:
+            print(f"[microprobe] run_root={probe_root} (could not estimate sec/step from log)")
+
+    # Full 2-seed datapoint.
+    run_roots: List[Path] = []
+    gate_rows: List[dict] = []
+    for seed in seeds2:
+        full_tag = f"{args.tag}_seed{int(seed)}"
+        chance = 1.0 / float(int(args.val_range))
+        abort_after = int(args.soft_cap_steps) if int(args.soft_cap_steps) > 0 else 0
+        abort_acc = float(chance) - float(args.soft_abort_margin) if abort_after > 0 else 0.0
+        run_root, _ = _run_boot(
+            repo_root=repo_root,
+            tag=full_tag,
+            seed=int(seed),
+            steps=int(args.steps),
+            seq_len=int(args.seq_len),
+            batch_size=int(args.batch_size),
+            max_samples=int(max(args.max_samples, args.eval_samples)),
+            eval_samples=int(args.eval_samples),
+            ring_len=int(args.ring_len),
+            slot_dim=int(args.slot_dim),
+            device=str(args.device),
+            lr=float(args.lr),
+            model=str(args.model),
+            prismn_n=int(args.prismn_n),
+            prismn_mode=str(args.prismn_mode),
+            prismn_shared=int(args.prismn_shared),
+            prismn_out_dim=int(args.prismn_out_dim),
+            prismn_id_scale=float(args.prismn_id_scale),
+            synth_mode=str(args.synth_mode),
+            keys=int(args.keys),
+            pairs=int(args.pairs),
+            val_range=int(args.val_range),
+            assoc_unique_keys=bool(args.assoc_unique_keys),
+            assoc_mq_dup=int(args.assoc_mq_dup),
+            assoc_mq_grouped=int(args.assoc_mq_grouped),
+            eval_disjoint=bool(args.eval_disjoint),
+            eval_ptr_deterministic=bool(args.eval_ptr_deterministic),
+            abort_after=abort_after,
+            abort_acc=abort_acc,
+        )
+        print(f"[run] seed={seed} run_root={run_root}")
+        run_roots.append(run_root)
+
+        # If the run was aborted early, don't spend time on high-precision eval.
+        r = _read_report(run_root)
+        steps_done = int((r.get("train") or {}).get("steps") or 0)
+        if steps_done >= int(args.steps):
+            _postmortem_eval(
+                repo_root=repo_root,
+                run_root=run_root,
+                checkpoint=_find_checkpoint(run_root),
+                eval_samples=int(args.hard_eval_samples),
+                batch_size=int(args.batch_size),
+                device=str(args.device),
+                prismn_id_scale=float(args.prismn_id_scale),
+            )
+        gate_rows.append(_gate_row(run_root=run_root))
+
+    _ingest_and_gate(repo_root)
+    print("[done] ingested + professor-gated results.")
+    for rr in run_roots:
+        print(f"[done] {rr}")
+    print(f"[done] dashboard: http://localhost:{int(args.dashboard_port)}")
+
+    # Print the binary decision for this 2-seed datapoint (hard gate).
+    passes = [bool(gr.get("pass")) for gr in gate_rows]
+    overall = "PASS" if all(passes) else ("UNSTABLE" if any(passes) else "FAIL")
+    print(f"[gate] overall={overall} hard_steps={int(args.steps)} hard_eval_n={int(args.hard_eval_samples)}")
+    for gr in gate_rows:
+        print(
+            "[gate] seed={seed} steps={steps} acc={acc:.6f} n={n} ci95={ci:.6f} lower95={lo:.6f} chance={ch:.6f} pass={ps}".format(
+                seed=gr.get("seed"),
+                steps=gr.get("steps"),
+                acc=float(gr.get("eval_acc") or 0.0),
+                n=int(gr.get("eval_n") or 0),
+                ci=float(gr.get("ci95") or 0.0),
+                lo=float(gr.get("lower95") or 0.0),
+                ch=float(gr.get("chance") or 0.0),
+                ps=bool(gr.get("pass")),
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Golden Draft/tools/eval_ckpt_assoc_byte.py
+++ b/Golden Draft/tools/eval_ckpt_assoc_byte.py
@@ -1,0 +1,394 @@
+"""Postmortem eval for synth assoc_byte runs (load checkpoint, run eval, write report.json).
+
+Problem this solves:
+- Training runs are often stopped early (manual stop at step ~200, etc.).
+- The boot benchmark writes report.json only when the run completes normally.
+- We need a deterministic way to evaluate an EXISTING checkpoint and persist results
+  into the SAME run_root so `tools/results_ingest.py` can pick it up.
+
+Usage:
+  python tools/eval_ckpt_assoc_byte.py --run-root S:\\...\\bench_vault\\benchmarks\\...\\<ts>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+import torch
+
+
+def _bootstrap_import_paths(repo_root: Path) -> None:
+    draftr = repo_root / "Golden Draft"
+    gcode = repo_root / "Golden Code"
+    if str(draftr) not in sys.path:
+        sys.path.insert(0, str(draftr))
+    if str(gcode) not in sys.path:
+        sys.path.insert(0, str(gcode))
+
+
+def _try_git_rev(repo_root: Path) -> Optional[str]:
+    try:
+        out = subprocess.check_output(
+            ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        return out.strip() or None
+    except Exception:
+        return None
+
+
+def _env_set(name: str, value: str) -> None:
+    os.environ[name] = value
+
+
+def _read_text(path: Path, max_bytes: int = 2_000_000) -> str:
+    with path.open("rb") as f:
+        data = f.read(max_bytes)
+    return data.decode("utf-8", errors="replace")
+
+
+def _infer_seed_from_path(run_root: Path) -> Optional[int]:
+    # Common run tags include "...seed222_..." somewhere in the path.
+    m = re.search(r"\bseed(\d+)\b", str(run_root).replace("\\", "/"))
+    if not m:
+        return None
+    try:
+        return int(m.group(1))
+    except Exception:
+        return None
+
+
+def _infer_synth_from_log(log_txt: str) -> Dict[str, Any]:
+    # Example:
+    # [synth] mode=assoc_byte rows=2000 keys=64 vals=16 pairs=4 mq_dup=1 len=128
+    m = re.search(
+        r"\[synth\]\s+mode=(?P<mode>\S+)\s+rows=(?P<rows>\d+)\s+keys=(?P<keys>\d+)\s+vals=(?P<vals>\d+)\s+pairs=(?P<pairs>\d+)\s+mq_dup=(?P<mq_dup>\d+)\s+len=(?P<seq_len>\d+)",
+        log_txt,
+    )
+    if not m:
+        raise RuntimeError("Could not infer synth settings from vraxion.log (missing [synth] header).")
+    out: Dict[str, Any] = dict(m.groupdict())
+    for k in ("rows", "keys", "vals", "pairs", "mq_dup", "seq_len"):
+        out[k] = int(out[k])
+    return out
+
+
+def _infer_eval_disjoint_from_log(log_txt: str) -> bool:
+    return bool(re.search(r"\[eval\]\s+split=disjoint\b", log_txt))
+
+
+def _infer_prismion_from_state(state: Dict[str, Any]) -> Dict[str, Any]:
+    # slot_dim via core.input_proj.weight: [slot_dim, input_dim]
+    slot_dim = int(state["core.input_proj.weight"].shape[0])
+
+    # ring_len via per-ring vectors.
+    ring_len = None
+    for k in ("core.theta_ptr_reduced", "core.theta_gate_reduced", "core.router_map"):
+        v = state.get(k)
+        if v is not None and hasattr(v, "shape") and len(v.shape) == 1:
+            ring_len = int(v.shape[0])
+            break
+    if ring_len is None:
+        raise RuntimeError("Could not infer ring_len from checkpoint tensors.")
+
+    # msg projection: shared msg_proj vs per-prismion msg_w/msg_b.
+    shared_msgproj = True
+    n = None
+    out_dim = None
+    if "msg_w" in state:
+        shared_msgproj = False
+        n = int(state["msg_w"].shape[0])
+        out_dim = int(state["msg_w"].shape[1])
+    elif "msg_proj.weight" in state:
+        shared_msgproj = True
+        out_dim = int(state["msg_proj.weight"].shape[0])
+        n = int(state["id_embed.weight"].shape[0]) if "id_embed.weight" in state else None
+    if n is None or out_dim is None:
+        raise RuntimeError("Could not infer prismion N/out_dim from checkpoint tensors.")
+
+    # head: [num_classes, head_in]
+    num_classes = int(state["head.weight"].shape[0])
+    head_in = int(state["head.weight"].shape[1])
+    if head_in == n * out_dim:
+        mode = "mosaic"
+    elif head_in == out_dim:
+        mode = "mean"
+    else:
+        mode = f"unknown(head_in={head_in})"
+
+    return {
+        "ring_len": ring_len,
+        "slot_dim": slot_dim,
+        "num_classes": num_classes,
+        "prismn_n": n,
+        "prismn_out_dim": out_dim,
+        "prismn_shared_msgproj": 1 if shared_msgproj else 0,
+        "prismn_mode": mode,
+    }
+
+
+def _loss_slope(losses: list[float], window: int = 50) -> float:
+    if not losses:
+        return 0.0
+    y = losses[-int(min(window, len(losses))) :]
+    if len(y) < 2:
+        return 0.0
+    n = float(len(y))
+    sx = (n - 1.0) * n / 2.0
+    sxx = (n - 1.0) * n * (2.0 * n - 1.0) / 6.0
+    sy = float(sum(y))
+    sxy = float(sum(i * yi for i, yi in enumerate(y)))
+    denom = (n * sxx - sx * sx)
+    if denom == 0.0:
+        return 0.0
+    return (n * sxy - sx * sy) / denom
+
+
+def _last_debug_from_log(log_txt: str) -> Dict[str, Any]:
+    last = None
+    for line in log_txt.splitlines():
+        if "| debug " in line:
+            last = line
+    if not last:
+        return {}
+    try:
+        jtxt = last.split("| debug ", 1)[1].strip()
+        return json.loads(jtxt)
+    except Exception:
+        return {}
+
+
+def _count_params(model: Any) -> Dict[str, int]:
+    total = 0
+    trainable = 0
+    for p in model.parameters():
+        n = int(p.numel())
+        total += n
+        if bool(getattr(p, "requires_grad", False)):
+            trainable += n
+    return {"total": int(total), "trainable": int(trainable)}
+
+
+def _count_module_params(mod: Any) -> int:
+    if mod is None:
+        return 0
+    try:
+        return int(sum(int(p.numel()) for p in mod.parameters()))
+    except Exception:
+        return 0
+
+
+def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--run-root", type=str, required=True)
+    p.add_argument("--checkpoint", type=str, default="")
+    p.add_argument("--eval-samples", type=int, default=4096)
+    p.add_argument("--batch-size", type=int, default=32)
+    p.add_argument("--eval-seed-offset", type=int, default=1000003)
+    p.add_argument("--device", type=str, default="cpu", choices=["cpu", "cuda"])
+    p.add_argument("--prismn-id-scale", type=float, default=0.02, help="Must match training if it was overridden.")
+    return p.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _parse_args(argv)
+    run_root = Path(args.run_root).resolve()
+    if not run_root.exists():
+        raise SystemExit(f"run_root not found: {run_root}")
+
+    ckpt_path = Path(args.checkpoint) if args.checkpoint else (run_root / "checkpoint_last_good.pt")
+    if not ckpt_path.exists():
+        ckpt_path = run_root / "checkpoint.pt"
+    if not ckpt_path.exists():
+        raise SystemExit(f"checkpoint not found: {ckpt_path}")
+
+    log_path = run_root / "vraxion.log"
+    if not log_path.exists():
+        raise SystemExit(f"vraxion.log not found: {log_path}")
+
+    repo_root = Path(__file__).resolve().parents[2]
+    _bootstrap_import_paths(repo_root)
+
+    from tools._checkpoint_io import atomic_json_dump, safe_torch_load  # type: ignore
+    from tools import instnct_data, instnct_eval, instnct_train_wallclock  # type: ignore
+    from vraxion.instnct import infra  # type: ignore
+    from vraxion.instnct.prismion_hallway_bank import PrismionHallwayBank  # type: ignore
+    from vraxion.instnct.seed import set_seed  # type: ignore
+
+    log_txt = _read_text(log_path)
+    synth = _infer_synth_from_log(log_txt)
+    eval_disjoint = _infer_eval_disjoint_from_log(log_txt)
+
+    ck = safe_torch_load(str(ckpt_path))
+    state = ck.get("model") or {}
+    prism = _infer_prismion_from_state(state)
+
+    seed = _infer_seed_from_path(run_root)
+    if seed is None:
+        seed = int(ck.get("step") or 0)
+
+    # Route all eval logs into the run_root for traceability.
+    _env_set("VAR_PROJECT_ROOT", str(run_root))
+    _env_set("VAR_LOGGING_PATH", str(run_root / "vraxion_eval.log"))
+    _env_set("VAR_COMPUTE_DEVICE", str(args.device))
+    _env_set("VRX_PRECISION", "fp32")
+    _env_set("VAR_RUN_SEED", str(int(seed)))
+
+    _env_set("VRX_RING_LEN", str(int(prism["ring_len"])))
+    _env_set("VRX_SLOT_DIM", str(int(prism["slot_dim"])))
+
+    _env_set("VRX_SYNTH", "1")
+    _env_set("VRX_SYNTH_MODE", str(synth["mode"]))
+    _env_set("VRX_SYNTH_LEN", str(int(synth["seq_len"])))
+    _env_set("VRX_ASSOC_KEYS", str(int(synth["keys"])))
+    _env_set("VRX_ASSOC_PAIRS", str(int(synth["pairs"])))
+    _env_set("VRX_ASSOC_VAL_RANGE", str(int(synth["vals"])))
+    _env_set("VRX_ASSOC_MQ_DUP", str(int(synth.get("mq_dup", 1))))
+
+    # Ensure the dataset is large enough for the requested eval sample count.
+    _env_set("VRX_MAX_SAMPLES", str(int(max(int(args.eval_samples), int(synth["rows"])))))
+    _env_set("VRX_EVAL_SAMPLES", str(int(args.eval_samples)))
+    _env_set("VRX_BATCH_SIZE", str(int(args.batch_size)))
+    _env_set("VRX_LR", "0.0")
+
+    _env_set("VRX_MODEL", "prismion_hallway_bank")
+    _env_set("VRX_PRISMN_N", str(int(prism["prismn_n"])))
+    _env_set("VRX_PRISMN_MODE", str(prism["prismn_mode"]))
+    _env_set("VRX_PRISMN_SHARED", str(int(prism["prismn_shared_msgproj"])))
+    _env_set("VRX_PRISMN_OUT_DIM", str(int(prism["prismn_out_dim"])))
+    _env_set("VRX_PRISMN_OUT_DTYPE", "fp64")
+    _env_set("VRX_PRISMN_ID_SCALE", str(float(args.prismn_id_scale)))
+
+    _env_set("VRX_EVAL_DISJOINT", "1" if eval_disjoint else "0")
+    _env_set("VRX_EVAL_SEED_OFFSET", str(int(args.eval_seed_offset)))
+
+    infra.ROOT = str(run_root)
+    infra.LOG_PATH = str(run_root / "vraxion_eval.log")
+    set_seed(int(seed))
+
+    loader, num_classes, collate = instnct_data.get_seq_mnist_loader(
+        train=True,
+        batch_size=int(args.batch_size),
+        max_samples=int(os.environ["VRX_MAX_SAMPLES"]),
+    )
+    if int(num_classes) != int(prism["num_classes"]):
+        infra.log(
+            f"[eval_ckpt] WARNING: num_classes mismatch ckpt={prism['num_classes']} loader={num_classes}"
+        )
+
+    spec = instnct_eval.EvalLoaderSpec(eval_samples=int(args.eval_samples), batch_size=int(args.batch_size))
+    if eval_disjoint:
+        set_seed(int(seed) + int(args.eval_seed_offset))
+        eval_src, _, eval_collate = instnct_data.get_seq_mnist_loader(
+            train=True,
+            batch_size=int(args.batch_size),
+            max_samples=int(os.environ["VRX_MAX_SAMPLES"]),
+        )
+        set_seed(int(seed))
+        eval_loader, eval_size = instnct_eval.build_eval_loader_from_dataset(
+            eval_src.dataset, spec=spec, input_collate=eval_collate
+        )
+        instnct_eval.log_eval_overlap(loader.dataset, eval_loader.dataset, eval_size, "disjoint", log=infra.log)
+    else:
+        eval_loader, eval_size = instnct_eval.build_eval_loader_from_subset(
+            loader.dataset, spec=spec, input_collate=collate
+        )
+        instnct_eval.log_eval_overlap(loader.dataset, eval_loader.dataset, eval_size, "subset", log=infra.log)
+
+    model = PrismionHallwayBank(
+        input_dim=1,
+        num_classes=int(prism["num_classes"]),
+        ring_len=int(prism["ring_len"]),
+        slot_dim=int(prism["slot_dim"]),
+    )
+    model.load_state_dict(state, strict=True)
+
+    params = _count_params(model)
+    params["head"] = _count_module_params(getattr(model, "head", None))
+    params["core"] = _count_module_params(getattr(model, "core", None))
+
+    eval_deps = instnct_eval.EvalDeps(
+        device=str(args.device),
+        dtype=torch.float32,
+        amp_autocast=instnct_train_wallclock.amp_autocast,
+        log=infra.log,
+        synth_mode=str(synth["mode"]),
+        mi_shuffle=False,
+        mitosis_enabled=False,
+    )
+    eval_sum = instnct_eval.eval_model(
+        model, eval_loader, "synth_assoc_byte", "prismion_hallway_bank", deps=eval_deps
+    )
+
+    losses = [float(x) for x in (ck.get("losses") or [])] if isinstance(ck.get("losses"), list) else []
+    debug_last = _last_debug_from_log(log_txt)
+
+    report: Dict[str, Any] = {
+        "benchmark": "eval_ckpt_assoc_byte",
+        "run_root": str(run_root),
+        "git_rev": _try_git_rev(repo_root),
+        "platform": {"python": sys.version.split()[0], "os": platform.platform()},
+        "settings": {
+            "device": str(args.device),
+            "dtype": "fp32",
+            "seed": int(seed),
+            "model": "prismion_hallway_bank",
+            "ring_len": int(prism["ring_len"]),
+            "slot_dim": int(prism["slot_dim"]),
+            "batch_size": int(args.batch_size),
+            "seq_len": int(synth["seq_len"]),
+            "max_samples": int(os.environ["VRX_MAX_SAMPLES"]),
+            "eval_samples": int(args.eval_samples),
+            "lr": 0.0,
+            "keys": int(synth["keys"]),
+            "pairs": int(synth["pairs"]),
+            "val_range": int(synth["vals"]),
+            "assoc_unique_keys": True,  # not inferable from logs; safe default for our current regime
+            "assoc_mq_dup": int(synth.get("mq_dup", 1)),
+            "assoc_mq_grouped": 1,
+            "eval_disjoint": bool(eval_disjoint),
+            "eval_seed_offset": int(args.eval_seed_offset),
+            "eval_ptr_deterministic": False,
+            "abort_after": 0,
+            "abort_acc": 0.0,
+        },
+        "prismion_bank": {
+            "n": int(prism["prismn_n"]),
+            "mode": str(prism["prismn_mode"]),
+            "shared": int(prism["prismn_shared_msgproj"]),
+            "shared_core": 1,
+            "shared_msgproj": int(prism["prismn_shared_msgproj"]),
+            "orbas": False,
+            "orbas_seed": 0,
+            "id_scale": float(args.prismn_id_scale),
+            "out_dim": int(prism["prismn_out_dim"]),
+            "out_dtype": "fp64",
+        },
+        "params": params,
+        "train": {
+            "steps": int(ck.get("step") or 0),
+            "loss_slope": float(_loss_slope(losses, window=50)),
+            **{k: debug_last.get(k) for k in debug_last.keys() if k.startswith("lane_")},
+        },
+        "eval_mid": None,
+        "eval": eval_sum,
+        "notes": "postmortem eval from checkpoint (no additional training)",
+    }
+
+    atomic_json_dump(report, str(run_root / "report.json"), indent=2)
+    infra.log(f"[eval_ckpt] report saved: {run_root / 'report.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Golden Draft/tools/ghost_wake.ps1
+++ b/Golden Draft/tools/ghost_wake.ps1
@@ -1,0 +1,111 @@
+<#
+Ghost Hand: loopback trigger for Codex/VRAXION long runs.
+
+This script watches for a JSON trigger file (wake_trigger.json) written by
+Golden Draft/tools/vraxion_lab_supervisor.py and, after a delay, focuses the
+target PowerShell window and "presses Enter" by sending a memo string.
+
+Notes:
+- For reliable focus, set your PowerShell window title to a stable string:
+    $host.UI.RawUI.WindowTitle = "VRAXION_CLI"
+  and set `--wake-window-title VRAXION_CLI` in the supervisor.
+- This script is intentionally dumb and robust. All "intelligence" lives in the
+  supervisor / agent; this only provides the physical wake-up signal.
+#>
+
+param(
+  [string]$TriggerPath = "S:\AI\work\VRAXION_DEV\bench_vault\wake_trigger.json",
+  [int]$PollSeconds = 2,
+  [int]$FocusDelayMs = 250
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Write-Log([string]$msg) {
+  $ts = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+  Write-Host ("[{0}] {1}" -f $ts, $msg)
+}
+
+function Try-AppActivate([string]$title) {
+  try {
+    Add-Type -AssemblyName Microsoft.VisualBasic | Out-Null
+    [Microsoft.VisualBasic.Interaction]::AppActivate($title) | Out-Null
+    Start-Sleep -Milliseconds $FocusDelayMs
+    return $true
+  } catch {
+    return $false
+  }
+}
+
+function Send-Memo([string]$memo) {
+  Add-Type -AssemblyName System.Windows.Forms | Out-Null
+  # SendWait is best-effort; keep memo single-line ASCII for reliability.
+  [System.Windows.Forms.SendKeys]::SendWait($memo)
+  Start-Sleep -Milliseconds 50
+  [System.Windows.Forms.SendKeys]::SendWait("{ENTER}")
+}
+
+Write-Log ("ghost_wake online. watching: {0}" -f $TriggerPath)
+
+while ($true) {
+  if (-not (Test-Path -LiteralPath $TriggerPath)) {
+    Start-Sleep -Seconds $PollSeconds
+    continue
+  }
+
+  $raw = Get-Content -LiteralPath $TriggerPath -Raw
+  if (-not $raw) {
+    Start-Sleep -Seconds $PollSeconds
+    continue
+  }
+
+  try {
+    $j = $raw | ConvertFrom-Json
+  } catch {
+    Write-Log "trigger json parse failed; will retry"
+    Start-Sleep -Seconds $PollSeconds
+    continue
+  }
+
+  $wakeAfter = 0
+  try { $wakeAfter = [int]$j.wake_after_s } catch { $wakeAfter = 0 }
+  if ($wakeAfter -lt 0) { $wakeAfter = 0 }
+
+  $memo = ""
+  try { $memo = [string]$j.memo } catch { $memo = "" }
+  if (-not $memo) { $memo = "[ghost_wake] ping" }
+
+  $title = ""
+  try { $title = [string]$j.window_title } catch { $title = "" }
+
+  Write-Log ("trigger detected (reason={0}) wake_after_s={1}" -f $j.reason, $wakeAfter)
+  Start-Sleep -Seconds $wakeAfter
+
+  if ($title) {
+    $ok = Try-AppActivate $title
+    if (-not $ok) {
+      Write-Log ("AppActivate failed for title '{0}'. sending to current active window." -f $title)
+    }
+  } else {
+    Write-Log "no window_title set; sending to current active window."
+  }
+
+  try {
+    Send-Memo $memo
+    Write-Log ("sent memo: {0}" -f $memo)
+  } catch {
+    Write-Log ("SendKeys failed: {0}" -f $_.Exception.Message)
+  }
+
+  try {
+    $dir = Split-Path -Parent $TriggerPath
+    $stamp = (Get-Date).ToUniversalTime().ToString("yyyyMMdd_HHmmss")
+    $dst = Join-Path $dir ("wake_trigger.processed_{0}.json" -f $stamp)
+    Move-Item -LiteralPath $TriggerPath -Destination $dst -Force
+    Write-Log ("archived trigger -> {0}" -f $dst)
+  } catch {
+    Write-Log ("failed to archive trigger: {0}" -f $_.Exception.Message)
+  }
+}
+

--- a/Golden Draft/tools/sweep_assoc_repulsion.py
+++ b/Golden Draft/tools/sweep_assoc_repulsion.py
@@ -1,0 +1,539 @@
+"""Deterministic repulsion (diversity) sweep for PrismionLiquid on assoc_byte.
+
+This is a "result-safe" runner:
+- Runs are only considered valid if `report.json` exists under the run root.
+- All runs are pinned to CPU + eval-disjoint so comparisons are meaningful.
+
+It is intentionally placed in Golden Draft tooling.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+
+@dataclass(frozen=True)
+class SweepPoint:
+    name: str
+    env: Dict[str, str]
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _bench_entrypoint(repo_root: Path) -> Path:
+    return repo_root / "Golden Draft" / "benchmarks" / "boot_synth_markov0" / "run_boot_synth_markov0.py"
+
+
+def _now_ts() -> str:
+    return time.strftime("%Y%m%d_%H%M%S")
+
+
+def _safe_tag(s: str) -> str:
+    # Keep Windows-friendly filenames.
+    out = []
+    for ch in str(s):
+        if ch.isalnum() or ch in ("_", "-", "."):
+            out.append(ch)
+        else:
+            out.append("_")
+    return "".join(out)
+
+
+def _ensure_dir(p: Path) -> None:
+    p.mkdir(parents=True, exist_ok=True)
+
+
+def _run_one(*, repo_root: Path, run_root: Path, extra_env: Dict[str, str], args: Sequence[str]) -> Path:
+    _ensure_dir(run_root)
+    env = dict(os.environ)
+    env.update(extra_env)
+    env["VAR_PROJECT_ROOT"] = str(run_root)
+    env["VAR_LOGGING_PATH"] = str(run_root / "vraxion.log")
+
+    bench = _bench_entrypoint(repo_root)
+    cmd = [sys.executable, "-u", str(bench), *args, "--respect-env"]
+    # Avoid flooding the console: capture child output into per-run log files.
+    out_path = run_root / "stdout.log"
+    err_path = run_root / "stderr.log"
+    with out_path.open("wb") as out_f, err_path.open("wb") as err_f:
+        rc = subprocess.call(cmd, env=env, stdout=out_f, stderr=err_f)
+    if rc != 0:
+        raise RuntimeError(f"bench entrypoint exited rc={rc}")
+
+    report = run_root / "report.json"
+    if not report.exists():
+        raise RuntimeError(f"missing report.json under {run_root}")
+    return run_root
+
+
+def _read_eval_acc(report_path: Path) -> float:
+    rep = json.loads(report_path.read_text(encoding="utf-8"))
+    ev = rep.get("eval", {}) or {}
+    return float(ev.get("eval_acc", 0.0))
+
+
+def _fmt_pct(x: float) -> str:
+    return f"{(100.0 * float(x)):.2f}%"
+
+
+def _base_env(*, seed: int, val_range: int, n: int) -> Dict[str, str]:
+    # Disable dashboard / autorun to keep this runner predictable.
+    env: Dict[str, str] = {
+        "VRX_LIVE": "0",
+        "VRX_LIVE_DASH": "0",
+        "VRX_LIVE_OPEN": "0",
+        "VAR_RUN_SEED": str(int(seed)),
+        "VAR_COMPUTE_DEVICE": "cpu",
+        # "Tax collection" fix: diversity penalty is routed through move_penalty.
+        "VRX_LMOVE": "1.0",
+        # Assoc-byte knobs.
+        "VRX_ASSOC_VAL_RANGE": str(int(val_range)),
+        # Keep fixed unless explicitly sweeping them.
+        "VRX_ASSOC_KEYS": "4",
+        "VRX_ASSOC_PAIRS": "3",
+        # Prismion mesh config (bank topology).
+        "VRX_PRISMION_TOPOLOGY": "bank",
+        "VRX_PRISMION_N": str(int(n)),
+        "VRX_PRISMION_TOPK": str(int(n)),  # update all (no starvation in update rule)
+        "VRX_PRISMION_ALPHA": "1.0",
+        "VRX_PRISMION_ID_SCALE": "0.10",
+        # Force off unrelated experimental couplings unless explicitly enabled.
+        "PRISMN_BUSINJ": "0",
+        "PRISMN_MIXING": "0",
+        "PRISMN_TUNING": "0",
+        "PRISMN_TGTDLT": "0",
+        "VRX_PRISMION_ALPHA_ADAPT": "0",
+        "VRX_THINK_RING": "0",
+    }
+    # Mosaic global integrator (global workspace lanes).
+    env["PRISMN_INTEG"] = "1"
+    env["PRISMN_IMODE"] = "mosaic"
+    env["PRISMN_IALPHA"] = "1.0"
+    return env
+
+
+def _bench_args(*, steps: int, seq_len: int, batch_size: int, max_samples: int, eval_samples: int, lr: float) -> List[str]:
+    return [
+        "--arch",
+        "prismion_liquid",
+        "--synth-mode",
+        "assoc_byte",
+        "--eval-disjoint",
+        "--steps",
+        str(int(steps)),
+        "--seq-len",
+        str(int(seq_len)),
+        "--batch-size",
+        str(int(batch_size)),
+        "--max-samples",
+        str(int(max_samples)),
+        "--eval-samples",
+        str(int(eval_samples)),
+        "--ring-len",
+        str(int(256)),
+        "--slot-dim",
+        str(int(128)),
+        "--device",
+        "cpu",
+        "--lr",
+        str(float(lr)),
+        "--tag",
+        "assoc_byte_repulsion_sweep",
+    ]
+
+
+def _plan_dvlam_sweep(*, base: Dict[str, str], dvtaus: float, dvlams: Iterable[float]) -> List[SweepPoint]:
+    pts: List[SweepPoint] = []
+    for lam in dvlams:
+        env = dict(base)
+        env["PRISMN_DVTAU"] = str(float(dvtaus))
+        env["PRISMN_DVLAM"] = str(float(lam))
+        name = f"dvlam_{lam:g}_tau_{dvtaus:g}"
+        pts.append(SweepPoint(name=name, env=env))
+    return pts
+
+
+def _plan_dvtau_sweep(*, base: Dict[str, str], dvlam: float, dvtaus: Iterable[float]) -> List[SweepPoint]:
+    pts: List[SweepPoint] = []
+    for tau in dvtaus:
+        env = dict(base)
+        env["PRISMN_DVLAM"] = str(float(dvlam))
+        env["PRISMN_DVTAU"] = str(float(tau))
+        name = f"dvlam_{dvlam:g}_tau_{tau:g}"
+        pts.append(SweepPoint(name=name, env=env))
+    return pts
+
+
+def _write_jsonl(path: Path, rows: List[Dict[str, object]]) -> None:
+    _ensure_dir(path.parent)
+    with path.open("a", encoding="utf-8") as f:
+        for r in rows:
+            f.write(json.dumps(r, sort_keys=True) + "\n")
+
+
+def _read_jsonl(path: Path) -> List[Dict[str, object]]:
+    if not path.exists():
+        return []
+    rows: List[Dict[str, object]] = []
+    for ln in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        s = ln.strip()
+        if not s:
+            continue
+        try:
+            rows.append(json.loads(s))
+        except Exception:
+            continue
+    return rows
+
+
+def _key_for_row(r: Dict[str, object]) -> str:
+    # Stable-ish dedupe key for resume.
+    return "|".join(
+        [
+            str(r.get("stage", "")),
+            str(r.get("name", "")),
+            str(r.get("seed", "")),
+            str(r.get("val_range", "")),
+            str(r.get("n", "")),
+            str(r.get("dvlambda", "")),
+            str(r.get("dvtau", "")),
+        ]
+    )
+
+
+def _parse_args(argv: Optional[Sequence[str]]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(prog="sweep_assoc_repulsion.py")
+    p.add_argument("--out-jsonl", default="", help="Write/append results to this jsonl (default: timestamped under bench_vault/sweeps).")
+    p.add_argument("--resume", action="store_true", help="If --out-jsonl exists, skip already-completed points.")
+    return p.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args_cli = _parse_args(argv)
+    repo_root = _repo_root()
+    out_dir = repo_root / "bench_vault" / "sweeps"
+    _ensure_dir(out_dir)
+
+    # Frozen experiment settings (fast gate).
+    seed0 = 126
+    val_range = 16
+    n = 3
+    steps = 300
+    seq_len = 128
+    batch_size = 32
+    max_samples = 2000
+    eval_samples = 512
+    lr = 1e-3
+
+    base = _base_env(seed=seed0, val_range=val_range, n=n)
+    bench_args = _bench_args(
+        steps=steps,
+        seq_len=seq_len,
+        batch_size=batch_size,
+        max_samples=max_samples,
+        eval_samples=eval_samples,
+        lr=lr,
+    )
+
+    # Stage 0: baseline (diversity off).
+    if str(args_cli.out_jsonl).strip():
+        results_jsonl = Path(str(args_cli.out_jsonl).strip())
+        if not results_jsonl.is_absolute():
+            results_jsonl = repo_root / results_jsonl
+    else:
+        results_jsonl = out_dir / f"assoc_byte_repulsion_sweep_{_now_ts()}.jsonl"
+
+    done: set[str] = set()
+    if bool(args_cli.resume) and results_jsonl.exists():
+        for r in _read_jsonl(results_jsonl):
+            done.add(_key_for_row(r))
+        print(f"[sweep] resume enabled: {len(done)} completed points found in {results_jsonl}")
+    rows: List[Dict[str, object]] = []
+
+    def _run_point(pt: SweepPoint) -> Tuple[float, Path]:
+        group = f"assoc_byte_v{val_range}_n{n}_mosaic"
+        tag = _safe_tag(f"{group}_{pt.name}")
+        run_root = repo_root / "bench_vault" / "benchmarks" / group / f"{_now_ts()}_{tag}"
+        _run_one(repo_root=repo_root, run_root=run_root, extra_env=pt.env, args=bench_args)
+        acc = _read_eval_acc(run_root / "report.json")
+        return acc, run_root
+
+    print("[sweep] Stage 0: baseline (diversity OFF)")
+    base0 = dict(base)
+    base0["PRISMN_DVLAM"] = "0.0"
+    base0["PRISMN_DVTAU"] = "0.1"
+    key0 = _key_for_row(
+        {
+            "stage": "baseline",
+            "name": "baseline_div0",
+            "seed": seed0,
+            "val_range": val_range,
+            "n": n,
+            "dvlambda": 0.0,
+            "dvtau": 0.1,
+        }
+    )
+    if key0 in done:
+        print("[sweep] baseline already present; loading as best_acc seed=126 from last row (best-effort)")
+        acc0 = 0.0
+        root0 = repo_root
+        for r in reversed(_read_jsonl(results_jsonl)):
+            if _key_for_row(r) == key0 and "eval_acc" in r:
+                try:
+                    acc0 = float(r.get("eval_acc", 0.0))
+                except Exception:
+                    acc0 = 0.0
+                try:
+                    root0 = Path(str(r.get("run_root", str(repo_root))))
+                except Exception:
+                    root0 = repo_root
+                break
+        print(f"[sweep] baseline disjoint eval acc (resumed): {_fmt_pct(acc0)}")
+    else:
+        try:
+            acc0, root0 = _run_point(SweepPoint(name="baseline_div0", env=base0))
+            row0: Dict[str, object] = {
+                "stage": "baseline",
+                "name": "baseline_div0",
+                "seed": seed0,
+                "val_range": val_range,
+                "n": n,
+                "dvlambda": 0.0,
+                "dvtau": 0.1,
+                "eval_acc": acc0,
+                "eval_acc_pct": _fmt_pct(acc0),
+                "run_root": str(root0),
+            }
+            rows.append(row0)
+            _write_jsonl(results_jsonl, rows)
+            done.add(_key_for_row(row0))
+            rows.clear()
+            print(f"[sweep] baseline disjoint eval acc: {_fmt_pct(acc0)}")
+        except Exception as e:
+            row0 = {
+                "stage": "baseline",
+                "name": "baseline_div0",
+                "seed": seed0,
+                "val_range": val_range,
+                "n": n,
+                "dvlambda": 0.0,
+                "dvtau": 0.1,
+                "error": repr(e),
+            }
+            rows.append(row0)
+            _write_jsonl(results_jsonl, rows)
+            rows.clear()
+            raise
+
+    # Stage 1: DVLAM ladder sweep.
+    print("[sweep] Stage 1: DVLAM ladder (DVTAU fixed at 0.1)")
+    # Baseline (diversity off) already ran in Stage 0, so omit 0.0 here.
+    dvlams = [1e-4, 3e-4, 1e-3, 3e-3, 1e-2, 3e-2, 1e-1]
+    best_lam = 0.0
+    best_acc = acc0
+    for pt in _plan_dvlam_sweep(base=base, dvtaus=0.1, dvlams=dvlams):
+        key = _key_for_row(
+            {
+                "stage": "dvlam",
+                "name": pt.name,
+                "seed": seed0,
+                "val_range": val_range,
+                "n": n,
+                "dvlambda": float(pt.env.get("PRISMN_DVLAM", "0.0")),
+                "dvtau": float(pt.env.get("PRISMN_DVTAU", "0.1")),
+            }
+        )
+        if key in done:
+            print(f"[sweep] skip (resume): {pt.name}")
+            continue
+
+        try:
+            acc, root = _run_point(pt)
+        except Exception as e:
+            lam = float(pt.env.get("PRISMN_DVLAM", "0.0"))
+            tau = float(pt.env.get("PRISMN_DVTAU", "0.1"))
+            row = {
+                "stage": "dvlam",
+                "name": pt.name,
+                "seed": seed0,
+                "val_range": val_range,
+                "n": n,
+                "dvlambda": lam,
+                "dvtau": tau,
+                "error": repr(e),
+            }
+            rows.append(row)
+            _write_jsonl(results_jsonl, rows)
+            done.add(_key_for_row(row))
+            rows.clear()
+            print(f"[sweep] {pt.name}: ERROR {e!r}")
+            continue
+        lam = float(pt.env.get("PRISMN_DVLAM", "0.0"))
+        tau = float(pt.env.get("PRISMN_DVTAU", "0.1"))
+        row = {
+            "stage": "dvlam",
+            "name": pt.name,
+            "seed": seed0,
+            "val_range": val_range,
+            "n": n,
+            "dvlambda": lam,
+            "dvtau": tau,
+            "eval_acc": acc,
+            "eval_acc_pct": _fmt_pct(acc),
+            "run_root": str(root),
+        }
+        rows.append(row)
+        if acc > best_acc:
+            best_acc = acc
+            best_lam = lam
+        print(f"[sweep] {pt.name}: {_fmt_pct(acc)}")
+        _write_jsonl(results_jsonl, rows)
+        done.add(_key_for_row(row))
+        rows.clear()
+
+    print(f"[sweep] best DVLAM so far: {best_lam:g} -> {_fmt_pct(best_acc)}")
+
+    # Stage 2: DVTAU sweep at best DVLAM (if non-zero).
+    print("[sweep] Stage 2: DVTAU sweep at best DVLAM")
+    dvtaus = [0.0, 0.05, 0.10, 0.20, 0.30]
+    best_tau = 0.1
+    best_pair_acc = best_acc
+    for pt in _plan_dvtau_sweep(base=base, dvlam=best_lam, dvtaus=dvtaus):
+        key = _key_for_row(
+            {
+                "stage": "dvtau",
+                "name": pt.name,
+                "seed": seed0,
+                "val_range": val_range,
+                "n": n,
+                "dvlambda": float(pt.env.get("PRISMN_DVLAM", "0.0")),
+                "dvtau": float(pt.env.get("PRISMN_DVTAU", "0.1")),
+            }
+        )
+        if key in done:
+            print(f"[sweep] skip (resume): {pt.name}")
+            continue
+
+        try:
+            acc, root = _run_point(pt)
+        except Exception as e:
+            lam = float(pt.env.get("PRISMN_DVLAM", "0.0"))
+            tau = float(pt.env.get("PRISMN_DVTAU", "0.1"))
+            row = {
+                "stage": "dvtau",
+                "name": pt.name,
+                "seed": seed0,
+                "val_range": val_range,
+                "n": n,
+                "dvlambda": lam,
+                "dvtau": tau,
+                "error": repr(e),
+            }
+            rows.append(row)
+            _write_jsonl(results_jsonl, rows)
+            done.add(_key_for_row(row))
+            rows.clear()
+            print(f"[sweep] {pt.name}: ERROR {e!r}")
+            continue
+        lam = float(pt.env.get("PRISMN_DVLAM", "0.0"))
+        tau = float(pt.env.get("PRISMN_DVTAU", "0.1"))
+        row = {
+            "stage": "dvtau",
+            "name": pt.name,
+            "seed": seed0,
+            "val_range": val_range,
+            "n": n,
+            "dvlambda": lam,
+            "dvtau": tau,
+            "eval_acc": acc,
+            "eval_acc_pct": _fmt_pct(acc),
+            "run_root": str(root),
+        }
+        rows.append(row)
+        if acc > best_pair_acc:
+            best_pair_acc = acc
+            best_tau = tau
+        print(f"[sweep] {pt.name}: {_fmt_pct(acc)}")
+        _write_jsonl(results_jsonl, rows)
+        done.add(_key_for_row(row))
+        rows.clear()
+
+    print(f"[sweep] best (DVLAM,DVTAU): ({best_lam:g},{best_tau:g}) -> {_fmt_pct(best_pair_acc)}")
+
+    # Stage 3: multi-seed confirmation for the best pair.
+    print("[sweep] Stage 3: confirm best pair across seeds 126/127/128")
+    seeds = [126, 127, 128]
+    for sd in seeds:
+        env = _base_env(seed=sd, val_range=val_range, n=n)
+        env["PRISMN_DVLAM"] = str(float(best_lam))
+        env["PRISMN_DVTAU"] = str(float(best_tau))
+        pt = SweepPoint(name=f"confirm_seed{sd}", env=env)
+        key = _key_for_row(
+            {
+                "stage": "confirm",
+                "name": pt.name,
+                "seed": sd,
+                "val_range": val_range,
+                "n": n,
+                "dvlambda": float(best_lam),
+                "dvtau": float(best_tau),
+            }
+        )
+        if key in done:
+            print(f"[sweep] skip (resume): {pt.name}")
+            continue
+
+        try:
+            acc, root = _run_point(pt)
+        except Exception as e:
+            row = {
+                "stage": "confirm",
+                "name": pt.name,
+                "seed": sd,
+                "val_range": val_range,
+                "n": n,
+                "dvlambda": float(best_lam),
+                "dvtau": float(best_tau),
+                "error": repr(e),
+            }
+            rows.append(row)
+            _write_jsonl(results_jsonl, rows)
+            done.add(_key_for_row(row))
+            rows.clear()
+            print(f"[sweep] seed={sd} -> ERROR {e!r}")
+            continue
+
+        row = {
+            "stage": "confirm",
+            "name": pt.name,
+            "seed": sd,
+            "val_range": val_range,
+            "n": n,
+            "dvlambda": float(best_lam),
+            "dvtau": float(best_tau),
+            "eval_acc": acc,
+            "eval_acc_pct": _fmt_pct(acc),
+            "run_root": str(root),
+        }
+        rows.append(row)
+        print(f"[sweep] seed={sd} -> {_fmt_pct(acc)}")
+        _write_jsonl(results_jsonl, rows)
+        done.add(_key_for_row(row))
+        rows.clear()
+
+    print(f"[sweep] results written: {results_jsonl}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Golden Draft/tools/vraxion_lab_supervisor.py
+++ b/Golden Draft/tools/vraxion_lab_supervisor.py
@@ -1,0 +1,425 @@
+"""Minimal run supervisor + loopback trigger for unattended VRAXION experiments.
+
+This tool exists because Codex turns are finite. For long runs we need:
+  - a supervisor that continues running after the chat turn ends
+  - crash recovery (auto-restart with backoff)
+  - a "wake trigger" file that an external "Ghost Hand" script can use to
+    re-activate the chat when something meaningful happens
+
+Design constraints:
+  - Stdlib only (no new deps)
+  - Append-only logs (never rewrite)
+  - Result-safe: treat the child as the source of truth; we only manage process
+    lifecycle + wake triggers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+
+def _utc_iso() -> str:
+    # time.strftime has no UTC ISO with millis; keep it simple + stable.
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _now_ts() -> str:
+    return time.strftime("%Y%m%d_%H%M%S")
+
+
+def _ensure_dir(p: Path) -> None:
+    p.mkdir(parents=True, exist_ok=True)
+
+
+def _atomic_write_json(path: Path, payload: Dict[str, Any]) -> None:
+    _ensure_dir(path.parent)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, sort_keys=True, indent=2), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _append_line(path: Path, line: str) -> None:
+    _ensure_dir(path.parent)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(line.rstrip("\n") + "\n")
+
+
+def _kill_pid_tree(pid: int) -> None:
+    if pid <= 0:
+        return
+    if os.name == "nt":
+        # /T = tree, /F = force
+        subprocess.call(["taskkill", "/PID", str(int(pid)), "/T", "/F"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return
+    try:
+        os.killpg(int(pid), 9)
+    except Exception:
+        try:
+            os.kill(int(pid), 9)
+        except Exception:
+            pass
+
+
+@dataclass(frozen=True)
+class WakeTrigger:
+    wake_after_s: int
+    memo: str
+    reason: str
+    job_root: str
+    attempt: int
+    pid: int
+    window_title: str = ""
+
+    def to_json(self) -> Dict[str, Any]:
+        return {
+            "version": 1,
+            "created_utc": _utc_iso(),
+            "wake_after_s": int(self.wake_after_s),
+            "memo": str(self.memo),
+            "reason": str(self.reason),
+            "job_root": str(self.job_root),
+            "attempt": int(self.attempt),
+            "pid": int(self.pid),
+            "window_title": str(self.window_title),
+        }
+
+
+def _default_repo_root() -> Path:
+    # Golden Draft/tools/<this_file>.py -> repo root is parents[2]
+    return Path(__file__).resolve().parents[2]
+
+
+def _default_job_root(repo_root: Path, job_name: str) -> Path:
+    safe = "".join(ch if (ch.isalnum() or ch in ("_", "-", ".")) else "_" for ch in job_name)
+    return repo_root / "bench_vault" / "jobs" / f"{_now_ts()}_{safe}"
+
+
+def _default_wake_trigger(repo_root: Path) -> Path:
+    return repo_root / "bench_vault" / "wake_trigger.json"
+
+
+def _parse_args(argv: Optional[Sequence[str]]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(prog="vraxion_lab_supervisor.py")
+    p.add_argument("--job-name", required=True, help="Human-readable name for logs/state.")
+    p.add_argument("--job-root", default="", help="Where to write logs/state. Default: bench_vault/jobs/<ts>_<job-name>")
+    p.add_argument("--wake-trigger", default="", help="Where to write wake_trigger.json. Default: bench_vault/wake_trigger.json")
+    p.add_argument("--wake-after-s", type=int, default=720, help="Delay before Ghost Hand sends the memo (seconds).")
+    p.add_argument(
+        "--wake-window-title",
+        default="",
+        help="Optional window title for ghost_wake.ps1 AppActivate (recommended).",
+    )
+    p.add_argument(
+        "--heartbeat-interval-s",
+        type=int,
+        default=0,
+        help="If >0, emit a wake trigger periodically while running (best-effort; won't overwrite an existing trigger).",
+    )
+    p.add_argument(
+        "--watchdog-no-output-s",
+        type=int,
+        default=0,
+        help="If >0, kill+restart child if it produces no stdout/stderr bytes for this many seconds.",
+    )
+    p.add_argument("--max-restarts", type=int, default=10, help="Maximum restart attempts after failures.")
+    p.add_argument("--restart-backoff-s", type=float, default=5.0, help="Initial backoff between restarts (seconds).")
+    p.add_argument(
+        "--stop-on-file",
+        default="",
+        help="If set, stop once this file exists (absolute or relative to repo root).",
+    )
+    p.add_argument(
+        "--stop-on-success",
+        action="store_true",
+        default=True,
+        help="Stop when the child exits with code 0 (default).",
+    )
+    p.add_argument(
+        "--no-stop-on-success",
+        action="store_false",
+        dest="stop_on_success",
+        help="Keep restarting even on exit code 0 (rare).",
+    )
+    p.add_argument(
+        "--",
+        dest="cmd_sep",
+        action="store_true",
+        help="Separator before the child command (everything after is the child command).",
+    )
+    p.add_argument("child_cmd", nargs=argparse.REMAINDER, help="Child command (prefix with --).")
+    return p.parse_args(list(argv) if argv is not None else None)
+
+
+def _resolve_stop_file(repo_root: Path, raw: str) -> Optional[Path]:
+    if not raw.strip():
+        return None
+    p = Path(raw.strip())
+    if p.is_absolute():
+        return p
+    return repo_root / p
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = _parse_args(argv)
+    if not args.child_cmd:
+        raise SystemExit("Missing child command. Usage: python vraxion_lab_supervisor.py --job-name X -- <cmd...>")
+    if args.child_cmd and args.child_cmd[0] == "--":
+        args.child_cmd = args.child_cmd[1:]
+
+    repo_root = _default_repo_root()
+    job_root = Path(args.job_root).expanduser() if str(args.job_root).strip() else _default_job_root(repo_root, args.job_name)
+    wake_trigger = Path(args.wake_trigger).expanduser() if str(args.wake_trigger).strip() else _default_wake_trigger(repo_root)
+    stop_file = _resolve_stop_file(repo_root, str(args.stop_on_file))
+
+    _ensure_dir(job_root)
+    sup_log = job_root / "supervisor.log"
+    out_log = job_root / "child_stdout.log"
+    err_log = job_root / "child_stderr.log"
+    state_path = job_root / "state.json"
+    config_path = job_root / "job.json"
+
+    _atomic_write_json(
+        config_path,
+        {
+            "version": 1,
+            "created_utc": _utc_iso(),
+            "job_name": args.job_name,
+            "job_root": str(job_root),
+            "wake_trigger": str(wake_trigger),
+            "wake_after_s": int(args.wake_after_s),
+            "wake_window_title": str(args.wake_window_title),
+            "heartbeat_interval_s": int(args.heartbeat_interval_s),
+            "watchdog_no_output_s": int(args.watchdog_no_output_s),
+            "max_restarts": int(args.max_restarts),
+            "restart_backoff_s": float(args.restart_backoff_s),
+            "stop_on_file": str(stop_file) if stop_file else "",
+            "stop_on_success": bool(args.stop_on_success),
+            "child_cmd": list(args.child_cmd),
+            "python": sys.executable,
+            "pid": int(os.getpid()),
+        },
+    )
+
+    attempt = 0
+    failures = 0
+    last_hb = 0.0
+    last_out_sz = 0
+    last_err_sz = 0
+    last_activity = time.monotonic()
+
+    _append_line(sup_log, f"[{_utc_iso()}] supervisor start pid={os.getpid()} job={args.job_name!r}")
+    _append_line(sup_log, f"[{_utc_iso()}] child cmd: {args.child_cmd!r}")
+    _append_line(sup_log, f"[{_utc_iso()}] job_root={job_root}")
+
+    while True:
+        if stop_file is not None and stop_file.exists():
+            _append_line(sup_log, f"[{_utc_iso()}] stop_file exists: {stop_file} (stopping)")
+            break
+
+        if failures > int(args.max_restarts):
+            _append_line(sup_log, f"[{_utc_iso()}] max restarts exceeded: failures={failures} (stopping)")
+            # Wake the user because this needs manual attention.
+            trig = WakeTrigger(
+                wake_after_s=int(args.wake_after_s),
+                memo=f"[vraxion_lab_supervisor] STOPPED: max restarts exceeded. job_root={job_root}",
+                reason="max_restarts",
+                job_root=str(job_root),
+                attempt=attempt,
+                pid=int(os.getpid()),
+                window_title=str(args.wake_window_title),
+            )
+            _atomic_write_json(wake_trigger, trig.to_json())
+            break
+
+        attempt += 1
+        _append_line(sup_log, f"[{_utc_iso()}] attempt={attempt} launching child")
+
+        env = dict(os.environ)
+        env["PYTHONUNBUFFERED"] = "1"
+        # Helpful breadcrumb in child logs.
+        env["VRX_SUPERVISOR_JOB_ROOT"] = str(job_root)
+        env["VRX_SUPERVISOR_ATTEMPT"] = str(int(attempt))
+
+        # Append-only: open in append mode.
+        with out_log.open("ab") as out_f, err_log.open("ab") as err_f:
+            popen_kwargs: Dict[str, Any] = {
+                "env": env,
+                "stdout": out_f,
+                "stderr": err_f,
+                "stdin": subprocess.DEVNULL,
+            }
+
+            # Create a new process group so we can kill the tree.
+            if os.name == "nt":
+                creationflags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+                popen_kwargs["creationflags"] = int(creationflags)
+            else:
+                popen_kwargs["start_new_session"] = True
+
+            try:
+                child = subprocess.Popen(list(args.child_cmd), **popen_kwargs)  # noqa: S603
+            except Exception as e:
+                failures += 1
+                _append_line(sup_log, f"[{_utc_iso()}] failed to launch child: {e!r}")
+                time.sleep(float(args.restart_backoff_s))
+                continue
+
+        child_pid = int(getattr(child, "pid", 0) or 0)
+        _atomic_write_json(
+            state_path,
+            {
+                "version": 1,
+                "updated_utc": _utc_iso(),
+                "attempt": int(attempt),
+                "failures": int(failures),
+                "child_pid": int(child_pid),
+                "child_running": True,
+                "child_cmd": list(args.child_cmd),
+            },
+        )
+
+        start_mono = time.monotonic()
+        last_hb = start_mono
+        last_activity = start_mono
+        last_out_sz = out_log.stat().st_size if out_log.exists() else 0
+        last_err_sz = err_log.stat().st_size if err_log.exists() else 0
+
+        poll_s = 1.0
+        watchdog_s = float(max(0, int(args.watchdog_no_output_s)))
+        hb_s = float(max(0, int(args.heartbeat_interval_s)))
+
+        while True:
+            if stop_file is not None and stop_file.exists():
+                _append_line(sup_log, f"[{_utc_iso()}] stop_file exists: {stop_file} (killing child pid={child_pid})")
+                _kill_pid_tree(child_pid)
+                break
+
+            rc = child.poll()
+            if rc is not None:
+                break
+
+            # Watchdog: did output logs move?
+            try:
+                out_sz = out_log.stat().st_size
+                err_sz = err_log.stat().st_size
+            except Exception:
+                out_sz = last_out_sz
+                err_sz = last_err_sz
+
+            if out_sz != last_out_sz or err_sz != last_err_sz:
+                last_activity = time.monotonic()
+                last_out_sz = out_sz
+                last_err_sz = err_sz
+
+            if watchdog_s > 0.0 and (time.monotonic() - last_activity) >= watchdog_s:
+                _append_line(
+                    sup_log,
+                    f"[{_utc_iso()}] watchdog: no output for {watchdog_s:.1f}s; killing child pid={child_pid}",
+                )
+                _kill_pid_tree(child_pid)
+                # Give the process a moment to exit.
+                time.sleep(0.5)
+                break
+
+            # Heartbeat wake trigger (best-effort; do not overwrite an existing trigger).
+            if hb_s > 0.0 and (time.monotonic() - last_hb) >= hb_s:
+                last_hb = time.monotonic()
+                if not wake_trigger.exists():
+                    elapsed = time.monotonic() - start_mono
+                    trig = WakeTrigger(
+                        wake_after_s=int(args.wake_after_s),
+                        memo=(
+                            f"[vraxion_lab_supervisor] heartbeat: still running (attempt={attempt} pid={child_pid} "
+                            f"elapsed_s={int(elapsed)}). job_root={job_root}"
+                        ),
+                        reason="heartbeat",
+                        job_root=str(job_root),
+                        attempt=int(attempt),
+                        pid=int(os.getpid()),
+                        window_title=str(args.wake_window_title),
+                    )
+                    _atomic_write_json(wake_trigger, trig.to_json())
+                    _append_line(sup_log, f"[{_utc_iso()}] wrote heartbeat wake trigger: {wake_trigger}")
+
+            time.sleep(poll_s)
+
+        # Child ended (or watchdog killed it).
+        rc = child.poll()
+        if rc is None:
+            try:
+                rc = child.wait(timeout=5.0)
+            except Exception:
+                rc = -1
+        rc = int(rc)
+
+        dur_s = time.monotonic() - start_mono
+        _append_line(sup_log, f"[{_utc_iso()}] child exit rc={rc} dur_s={dur_s:.1f} pid={child_pid}")
+
+        _atomic_write_json(
+            state_path,
+            {
+                "version": 1,
+                "updated_utc": _utc_iso(),
+                "attempt": int(attempt),
+                "failures": int(failures),
+                "child_pid": int(child_pid),
+                "child_running": False,
+                "child_exit_code": int(rc),
+                "child_duration_s": float(dur_s),
+                "child_cmd": list(args.child_cmd),
+            },
+        )
+
+        if rc == 0 and bool(args.stop_on_success):
+            trig = WakeTrigger(
+                wake_after_s=int(args.wake_after_s),
+                memo=f"[vraxion_lab_supervisor] DONE rc=0 attempt={attempt} job_root={job_root}",
+                reason="done",
+                job_root=str(job_root),
+                attempt=int(attempt),
+                pid=int(os.getpid()),
+                window_title=str(args.wake_window_title),
+            )
+            _atomic_write_json(wake_trigger, trig.to_json())
+            _append_line(sup_log, f"[{_utc_iso()}] wrote done wake trigger: {wake_trigger}")
+            break
+
+        failures += 1
+
+        # Wake user on crash, but do not overwrite an existing trigger (avoid spam).
+        if not wake_trigger.exists():
+            trig = WakeTrigger(
+                wake_after_s=int(args.wake_after_s),
+                memo=(
+                    f"[vraxion_lab_supervisor] CRASH rc={rc} attempt={attempt} failures={failures} "
+                    f"(auto-restarting). job_root={job_root}"
+                ),
+                reason="crash",
+                job_root=str(job_root),
+                attempt=int(attempt),
+                pid=int(os.getpid()),
+                window_title=str(args.wake_window_title),
+            )
+            _atomic_write_json(wake_trigger, trig.to_json())
+            _append_line(sup_log, f"[{_utc_iso()}] wrote crash wake trigger: {wake_trigger}")
+
+        # Exponential-ish backoff with a cap.
+        backoff = float(args.restart_backoff_s) * min(6.0, 1.0 + 0.5 * float(failures))
+        _append_line(sup_log, f"[{_utc_iso()}] backoff {backoff:.1f}s before restart")
+        time.sleep(backoff)
+
+    _append_line(sup_log, f"[{_utc_iso()}] supervisor exit job_root={job_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
Imports the unattended-run supervisor + loopback wake tooling from the previous C:\Users\kenes\Golden Draft shadow tree.

Adds (Golden Draft/tools):
- vraxion_lab_supervisor.py (stdlib-only watchdog + wake_trigger.json writer)
- ghost_wake.ps1 (SendKeys loopback trigger)
- auto_wake_protocol.md (how to run supervisor + ghost hand)

Also imports a few related run harness scripts and scratch helpers used by PLANLAB/overnight runs.

Tests:
- python -m unittest discover -s "S:\AI\work\VRAXION_DEV\Golden Draft\tests" -v
