### PR TITLE
fix(sync): force UTF-8 for gh subprocess output

### DIFF
--- a/Golden Draft/tools/vrx_sync_linear_projects.py
+++ b/Golden Draft/tools/vrx_sync_linear_projects.py
@@ -78,6 +78,8 @@ def _run(cmd: Sequence[str], *, cwd: Optional[Path] = None) -> subprocess.Comple
         cwd=str(cwd) if cwd is not None else None,
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         check=False,
     )
 


### PR DESCRIPTION
Windows locale encoding can cause UnicodeDecodeError when decoding UTF-8 output from gh (notably when JSON includes non-ASCII from Linear descriptions).

Force UTF-8 decoding for all gh subprocess calls to prevent sync crashes mid-run.