### PR TITLE
Audit: repo snapshot + entrypoints map (v1)

### DIFF
--- a/Golden Draft/docs/audit/entrypoints_v1.md
+++ b/Golden Draft/docs/audit/entrypoints_v1.md
@@ -1,0 +1,26 @@
+# Entrypoints v1
+
+This document is a pragmatic map of "things you can run" in this repo (scripts and common commands).
+It is intentionally conservative: if an entrypoint is likely to start heavy GPU work immediately, it is marked **unsafe to run blindly**.
+
+Legend:
+- **Golden Code**: code intended to be reusable / closer to "production".
+- **Golden Draft**: experiments + tooling (fast iteration, but still expected to be reproducible).
+
+## Safe entrypoints (recommended for first contact)
+
+| Name | Path / Command | What it does | Expected outputs |
+|---|---|---|---|
+| Unit tests (CPU) | `python -m unittest discover -s "Golden Draft/tests" -v` | Runs CPU-only regression tests for tooling/contracts. | Console output (no files). |
+| Bytecode sanity | `python -m compileall "Golden Code" "Golden Draft"` | Catches obvious syntax/import issues. | Console output (no files). |
+| GPU env dump (VRA-29) | `python "Golden Draft/tools/gpu_env_dump.py" --out-dir <DIR> --precision fp16 --amp 1` | Writes a stable `env.json` describing GPU/runtime context (best-effort; works without CUDA). | `<DIR>/env.json` |
+| Workload ID | `python "Golden Draft/tools/workload_id.py" <workload_json>` | Canonicalizes a workload spec and prints `workload_id`. | Console output (or JSON with `--json`). |
+| GPU capacity probe (VRA-32) | `python "Golden Draft/tools/gpu_capacity_probe.py" --help` | Probe harness for throughput/VRAM/stability metrics. Use `--help` first; runs write artifacts and are overwrite-guarded. | `env.json`, `metrics.json`, `metrics.csv`, `summary.md`, `run_cmd.txt` |
+| Lab supervisor / watchdog | `python "Golden Draft/tools/vraxion_lab_supervisor.py" --help` | Supervises long runs (heartbeat/watchdog + optional wake trigger). | Job logs + watchdog artifacts (depends on args). |
+
+## Potentially heavy entrypoints (read first)
+
+| Name | Path | Notes (read before running) |
+|---|---|---|
+| VRAXION runner | `Golden Draft/vraxion_run.py` | **Unsafe to run blindly.** Appears to start a run immediately (may default to CUDA). Read the file header and config expectations first. |
+| Infinite runner | `Golden Draft/VRAXION_INFINITE.py` | **Unsafe to run blindly.** Intended for long-running loops / nightmode-style work. Read first. |

--- a/Golden Draft/docs/audit/repo_audit_v1.md
+++ b/Golden Draft/docs/audit/repo_audit_v1.md
@@ -1,0 +1,62 @@
+# Repo Audit v1
+
+Date: 2026-02-05
+
+This is a lightweight, audit-first snapshot of what's in the repo and what's missing for a "new engineer can onboard fast" experience. It is deliberately descriptive (truth visible) and avoids behavior changes.
+
+## What exists today
+
+### Code layout
+- `Golden Code/`: "closer to production" Python package code (e.g., `Golden Code/vraxion/...`).
+- `Golden Draft/`: experiments + tooling. This is where the GPU contracts and probe tooling live.
+- `docs/`: GitHub Pages site (public-facing project documentation + diagrams).
+
+### GPU measurement + reproducibility tooling
+- GPU objective/stability contract: `Golden Draft/docs/gpu/objective_contract_v1.md` (doc-first; treated as a hard contract).
+- Env capture tool (VRA-29): `Golden Draft/tools/gpu_env_dump.py` (writes `env.json`).
+- Probe harness (VRA-32): `Golden Draft/tools/gpu_capacity_probe.py` (writes `metrics.json/csv`, `summary.md`, etc.).
+- Workload ID tooling: `Golden Draft/tools/workload_id.py` (canonicalization + deterministic identifiers).
+- Probe outputs / scratch: `bench_vault/` (should remain ignored; do not commit run artifacts).
+
+### Tests
+- Unit tests live under `Golden Draft/tests/` and run with:
+  - `python -m unittest discover -s "Golden Draft/tests" -v`
+
+### Repo meta + licensing
+- License + commercial terms: `LICENSE`, `COMMERCIAL_LICENSE.md`
+- Citation metadata: `CITATION.cff`
+
+### GitHub plumbing
+- PR template: `.github/pull_request_template.md`
+- Public update issue template: `.github/ISSUE_TEMPLATE/public_update.md`
+- (Currently missing) CI workflows under `.github/workflows/`
+
+## What's missing (for a professional / reproducible repo)
+
+These are workflow basics that reduce ambiguity for contributors and reviewers:
+- **Quickstart docs**: how to run tests and basic tooling on a clean checkout (CPU and GPU probe).
+- **Repro checklist**: what must be captured to make any performance claim verifiable (commit, seed, `env.json`, `workload_id`, args, outputs).
+- **Governance files**: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`.
+- **CI**: CPU-only test run on PRs so regressions get caught automatically (no CUDA required).
+
+## Risky cleanup candidates (do not do in v1)
+
+These are real, but fixing them tends to create large diffs or break scripts:
+- Space-in-path directories (`Golden Draft/`, `Golden Code/`) make some tooling awkward on Linux/shell scripts.
+- Drift between public site (`docs/`) and internal contracts/tools (`Golden Draft/docs/`).
+- Run artifact sprawl (`bench_vault/`, `logs/`): must remain ignored and never committed.
+
+## Immediate quick wins (<= 1 day, PR-safe)
+
+This repo-professionalization v1 intentionally focuses on small PRs:
+1) Audit snapshot + entrypoints map (this doc + `tree_depth6.txt` + `entrypoints_v1.md`).
+2) Quickstart + reproducibility docs + small `README.md` upgrade.
+3) Contribution/security templates so GitHub intake is structured.
+4) CPU-only CI that runs `unittest` + `compileall` on PRs.
+
+## Deferred changes (explicitly out of scope for v1)
+
+- Rename directories to remove spaces and standardize casing.
+- Convert to an installable Python package with a single CLI entrypoint.
+- Add Ubuntu CI and/or self-hosted GPU runners.
+- Consolidate experimental scripts/runners (once Chapter gates allow it).

--- a/Golden Draft/docs/audit/tree_depth6.txt
+++ b/Golden Draft/docs/audit/tree_depth6.txt
@@ -1,0 +1,154 @@
+./
+|-- .github/
+|   |-- ISSUE_TEMPLATE/
+|   |   `-- public_update.md
+|   `-- pull_request_template.md
+|-- docs/
+|   |-- assets/
+|   |   |-- At_a_glance.svg
+|   |   |-- auto_annealing.svg
+|   |   |-- cache_ram_hdd.svg
+|   |   |-- cadence_knee.svg
+|   |   |-- gpu_ch1_pipeline.svg
+|   |   |-- recursive_refinery.svg
+|   |   |-- vraxion_logo.svg
+|   |   `-- vraxion_phases.svg
+|   |-- .nojekyll
+|   |-- _config.yml
+|   |-- app.js
+|   |-- index.html
+|   |-- index_prev.md
+|   |-- input_flow.svg
+|   `-- styles.css
+|-- Golden Code/
+|   `-- vraxion/
+|       |-- instnct/
+|       |   |-- __init__.py
+|       |   |-- absolute_hallway.py
+|       |   |-- agc.py
+|       |   |-- brainstem.py
+|       |   |-- cadence.py
+|       |   |-- controls.py
+|       |   |-- experts.py
+|       |   |-- inertia_auto.py
+|       |   |-- infra.py
+|       |   |-- modular_checkpoint.py
+|       |   |-- panic.py
+|       |   |-- seed.py
+|       |   |-- settings.py
+|       |   |-- sharding.py
+|       |   |-- thermo.py
+|       |   `-- vcog.py
+|       |-- __init__.py
+|       `-- settings.py
+|-- Golden Draft/
+|   |-- benchmarks/
+|   |   |-- boot_synth_assoc_byte/
+|   |   |-- boot_synth_markov0/
+|   |   `-- boot_tiny_shakespeare/
+|   |-- contracts/
+|   |   |-- instnct_controls_golden_expected.json
+|   |   `-- instnct_settings_golden_expected.json
+|   |-- docs/
+|   |   |-- audit/
+|   |   |   `-- tree_depth6.txt
+|   |   |-- gpu/
+|   |   |   |-- env_lock_v1.md
+|   |   |   |-- objective_contract_v1.md
+|   |   |   |-- vram_breakdown_v1.md
+|   |   |   `-- workload_schema_v1.md
+|   |   |-- linear/
+|   |   |   `-- README.md
+|   |   |-- ops/
+|   |   |   `-- github_analytics_forensics_v1.md
+|   |   `-- ideas.md
+|   |-- tests/
+|   |   |-- conftest.py
+|   |   |-- test_absolute_hallway.py
+|   |   |-- test_cadence_governor.py
+|   |   |-- test_checkpoint_tools.py
+|   |   |-- test_controls_extra.py
+|   |   |-- test_env_utils.py
+|   |   |-- test_expert_routing.py
+|   |   |-- test_experts_hash.py
+|   |   |-- test_gpu_capacity_probe.py
+|   |   |-- test_gpu_env_dump.py
+|   |   |-- test_instnct_data.py
+|   |   |-- test_instnct_entrypoint.py
+|   |   |-- test_instnct_eval.py
+|   |   |-- test_instnct_evolution.py
+|   |   |-- test_instnct_seed_modular_override.py
+|   |   |-- test_instnct_train_steps.py
+|   |   |-- test_instnct_train_wallclock.py
+|   |   |-- test_linear_labels_catalog.py
+|   |   |-- test_live_dashboard_parse.py
+|   |   |-- test_modular_checkpoint.py
+|   |   |-- test_run_db.py
+|   |   |-- test_run_db_cmd_passthrough.py
+|   |   |-- test_settings_env_overrides.py
+|   |   |-- test_sharding_additional.py
+|   |   |-- test_thermostat.py
+|   |   |-- test_vcog_parse.py
+|   |   |-- test_vra60_watchdog_clock.py
+|   |   |-- test_vraxion_mitosis_split.py
+|   |   |-- test_vrx_sync_block.py
+|   |   `-- test_workload_id.py
+|   |-- tools/
+|   |   |-- _scratch/
+|   |   |   |-- check_latest_vraxion_log.py
+|   |   |   |-- launch_results_dashboard.py
+|   |   |   |-- print_report_summary.py
+|   |   |   |-- results_audit.py
+|   |   |   `-- run_transistor_sweep.py
+|   |   |-- __init__.py
+|   |   |-- _checkpoint_io.py
+|   |   |-- auto_wake_protocol.md
+|   |   |-- datapoint_2seed_runner.py
+|   |   |-- env_utils.py
+|   |   |-- eval_ckpt_assoc_byte.py
+|   |   |-- eval_only.py
+|   |   |-- ghost_wake.ps1
+|   |   |-- gpu_capacity_probe.py
+|   |   |-- gpu_capacity_probe_stub.py
+|   |   |-- gpu_env_dump.py
+|   |   |-- instnct_data.py
+|   |   |-- instnct_entrypoint.py
+|   |   |-- instnct_eval.py
+|   |   |-- instnct_evolution.py
+|   |   |-- instnct_runner.py
+|   |   |-- instnct_seed.py
+|   |   |-- instnct_train_steps.py
+|   |   |-- instnct_train_wallclock.py
+|   |   |-- linear_labels_catalog.py
+|   |   |-- live_dashboard.py
+|   |   |-- log_headers.py
+|   |   |-- modularize_checkpoint.py
+|   |   |-- parse_vcog.py
+|   |   |-- run_db.py
+|   |   |-- run_db_query.py
+|   |   |-- sweep_assoc_repulsion.py
+|   |   |-- vault_pack.py
+|   |   |-- vcog_parse.py
+|   |   |-- verify_golden_instnct_controls.py
+|   |   |-- verify_golden_instnct_experts_tools.py
+|   |   |-- verify_golden_instnct_settings.py
+|   |   |-- vraxion_lab_supervisor.py
+|   |   |-- vraxion_prune_merge.py
+|   |   |-- vrx_sync_linear_projects.py
+|   |   `-- workload_id.py
+|   |-- workloads/
+|   |   |-- od1_real_v1.json
+|   |   |-- od1_small_v1.json
+|   |   `-- od1_stress_v1.json
+|   |-- VRAXION_INFINITE.py
+|   |-- vraxion_mitosis_split.py
+|   `-- vraxion_run.py
+|-- .gitattributes
+|-- .gitignore
+|-- .vrx_sync_state.json
+|-- CITATION.cff
+|-- COMMERCIAL_LICENSE.md
+|-- LICENSE
+|-- NOTICE
+|-- README.md
+`-- VERSION.json


### PR DESCRIPTION
Why\n- Make repo truth visible for onboarding/review without changing behavior.\n\nWhat changed\n- Add audit docs under Golden Draft/docs/audit/:\n  - epo_audit_v1.md (what exists / gaps / quick wins)\n  - 	ree_depth6.txt (depth-limited tree snapshot)\n  - ntrypoints_v1.md (safe-to-run entrypoints + warnings)\n\nHow to verify\n- Open the new markdown files and confirm paths/commands resolve.\n- No code/runtime behavior is changed.