### PR TITLE
Docs: quickstart + reproducibility + README refresh (v1)

### DIFF
--- a/Golden Draft/docs/ops/quickstart_v1.md
+++ b/Golden Draft/docs/ops/quickstart_v1.md
@@ -1,0 +1,68 @@
+# Quickstart v1
+
+Goal: a new engineer can run **CPU tests** and understand the **GPU probe harness** in under ~10 minutes.
+
+## Prereqs
+
+- Python: **3.11** recommended.
+- OS: Windows is the currently verified development surface.
+
+## 1) Create a virtual environment
+
+From repo root:
+
+```powershell
+python -m venv .venv
+# If Activate.ps1 is blocked, you can use: Set-ExecutionPolicy -Scope Process Bypass
+.\.venv\Scripts\Activate.ps1
+python -m pip install -U pip
+```
+
+## 2) Install minimal dependencies
+
+This repo intentionally does not ship a one-size-fits-all requirements lock yet.
+
+Minimum for tooling/tests:
+
+```powershell
+pip install numpy
+```
+
+For GPU/torch tooling, install PyTorch for your platform. CPU-only example:
+
+```powershell
+pip install torch --index-url https://download.pytorch.org/whl/cpu
+```
+
+## 3) Run the CPU test suite
+
+```powershell
+python -m unittest discover -s "Golden Draft/tests" -v
+```
+
+## 4) Sanity compile gate
+
+```powershell
+python -m compileall "Golden Code" "Golden Draft"
+```
+
+## 5) GPU tooling (safe to inspect)
+
+The probe harness (VRA-32) prints help and enforces an overwrite guard for output dirs:
+
+```powershell
+python "Golden Draft/tools/gpu_capacity_probe.py" --help
+```
+
+The env dump tool (VRA-29) writes `env.json` and is best-effort (works without CUDA):
+
+```powershell
+python "Golden Draft/tools/gpu_env_dump.py" --out-dir bench_vault/_tmp/env_dump --precision unknown --amp 0
+```
+
+## Common failures (and where to look)
+
+- CUDA missing: expected on CPU machines. GPU probe runs require a working CUDA torch install.
+- Windows WDDM stalls / timeouts: see `Golden Draft/docs/gpu/env_lock_v1.md`.
+- VRAM oversubscription / paging symptoms: see `Golden Draft/docs/gpu/vram_breakdown_v1.md` and the stability gates in `Golden Draft/docs/gpu/objective_contract_v1.md`.
+- Logging sync traps (accidental `cuda.synchronize()` via `.item()` loops): see `Golden Draft/docs/gpu/env_lock_v1.md`.

--- a/Golden Draft/docs/ops/reproducibility_v1.md
+++ b/Golden Draft/docs/ops/reproducibility_v1.md
@@ -1,0 +1,48 @@
+# Reproducibility v1
+
+VRAXION performance claims are only useful if they are reproducible. This doc defines the **minimum result packet** for any benchmark/probe claim.
+
+## Result packet (required for any claim)
+
+Always record:
+
+- `git_commit`: exact commit hash (and branch name if relevant)
+- `VERSION.json`: the repo cadence version (MAJOR.MINOR.BUILD)
+- `env.json`: emitted by `Golden Draft/tools/gpu_env_dump.py`
+- `workload_id`: emitted by `Golden Draft/tools/workload_id.py` or by the probe harness
+- Full CLI args / mapping notes (prefer `run_cmd.txt` emitted by harnesses)
+- Output directory path containing raw artifacts (`metrics.json`, `metrics.csv`, `summary.md`)
+- Seed(s) if the run is stochastic
+
+If you cannot provide the above, treat the number as anecdotal.
+
+## Canonical output layout
+
+Use `bench_vault/_tmp/` for local run artifacts (it should remain ignored by git):
+
+- `bench_vault/_tmp/<ticket_or_experiment>/<probe_id_or_run_name>/`
+  - `env.json`
+  - `run_cmd.txt`
+  - `metrics.json`
+  - `metrics.csv`
+  - `summary.md`
+
+## GPU probe contract
+
+The probe harness is contract-driven:
+
+- Objective/stability contract: `Golden Draft/docs/gpu/objective_contract_v1.md`
+
+If you change what is measured or what constitutes PASS/FAIL, you must:
+
+1) update the contract version or add an explicit contract addendum, and
+2) keep backward compatibility for existing metrics consumers.
+
+## Notes on Windows WDDM
+
+Windows WDDM can enter regimes where step-times explode and VRAM behavior becomes misleading (paging/overcommit).
+The contract treats these as stability failures, and documentation should call out when a datapoint came from a degraded regime.
+
+See:
+- `Golden Draft/docs/gpu/env_lock_v1.md`
+- `Golden Draft/docs/gpu/vram_breakdown_v1.md`

--- a/README.md
+++ b/README.md
@@ -1,17 +1,46 @@
 # VRAXION Golden Targets
 
+VRAXION is a research codebase centered on **repeatable internal mechanisms** (loops/recurrence) and **instrumented evaluation** (so performance claims come with artifacts, not vibes).
+
 This repo root contains two curated targets:
 
 - `Golden Code/`: end-user ("DVD") runtime library code only.
   - Primary package: `Golden Code/vraxion/`
-- `Golden Draft/`: production-quality, non-DVD code (tools, tests, harness).
+- `Golden Draft/`: production-quality, non-DVD code (tools, tests, harness, contracts).
+
+## Status
+
+Research preview. Chapter #1 work (GPU limiter / probe harness / VRAM accounting) is active, so expect iteration and occasional breaking changes.
 
 ## Where to look
 
 - Pages (landing): https://kenessy.github.io/VRAXION/
 - Wiki (deep dives): https://github.com/Kenessy/VRAXION/wiki
+- Quickstart (local dev): `Golden Draft/docs/ops/quickstart_v1.md`
+- Reproducibility checklist: `Golden Draft/docs/ops/reproducibility_v1.md`
+- GPU objective/stability contract: `Golden Draft/docs/gpu/objective_contract_v1.md`
 - Roadmap (public): https://github.com/users/Kenessy/projects/4
 - Releases (public proof): https://github.com/Kenessy/VRAXION/releases
+
+## Quickstart (safe commands)
+
+CPU tests (recommended first command):
+
+```powershell
+python -m unittest discover -s "Golden Draft/tests" -v
+```
+
+Probe harness help (safe; does not run a benchmark):
+
+```powershell
+python "Golden Draft/tools/gpu_capacity_probe.py" --help
+```
+
+Sanity compile gate:
+
+```powershell
+python -m compileall "Golden Code" "Golden Draft"
+```
 
 ## Versioning (MAJOR.MINOR.BUILD)
 
@@ -22,23 +51,6 @@ VRAXION uses a simple cadence tracker stored in `VERSION.json`:
 - `MAJOR` increments only for lifetime milestones (MINOR resets to 0; BUILD unchanged).
 
 This does not replace the historical release tag `v1.0.0`.
-
-## Quick commands
-
-From `Golden Draft/`:
-
-```powershell
-python vraxion_run.py
-python VRAXION_INFINITE.py
-python tools/eval_only.py
-python -m unittest discover -s tests -v
-```
-
-Sanity compile gate:
-
-```powershell
-python -m compileall "Golden Code" "Golden Draft"
-```
 
 ## Naming conventions
 


### PR DESCRIPTION
Why
- Reduce onboarding friction: new engineers can run CPU tests and understand the probe harness quickly.

What changed
- Refresh README.md with status, repo map, and safe quickstart commands.
- Add:
  - Golden Draft/docs/ops/quickstart_v1.md
  - Golden Draft/docs/ops/reproducibility_v1.md

How to verify
- Open the docs and confirm commands are repo-relative.
- Run: python -m unittest discover -s "Golden Draft/tests" -v
