### PR TITLE
Chore: governance docs + issue intake config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: VRAXION Discussions
+    url: https://github.com/Kenessy/VRAXION/discussions
+    about: Questions, design discussion, and general conversation.
+  - name: Security reports
+    url: https://github.com/Kenessy/VRAXION/security/advisories/new
+    about: Please report vulnerabilities privately via GitHub Security Advisories.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,39 @@
+# Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Focusing on what is best for the community
+
+Examples of unacceptable behavior:
+
+- Harassment of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement responsibilities
+
+Project maintainers are responsible for clarifying and enforcing standards of acceptable behavior.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers.
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1:
+https://www.contributor-covenant.org/version/2/1/code_of_conduct/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing
+
+VRAXION is a research repo where **mechanism + repeatability > vibes**.
+If a change cannot be reproduced or audited, it is not done.
+
+## Repo map
+
+- `Golden Code/`: reusable runtime library code.
+- `Golden Draft/`: tooling, tests, harnesses, and experiment-grade code.
+- `docs/`: GitHub Pages site (public-facing).
+
+## Where to put things
+
+- Tools / harnesses / scripts: `Golden Draft/tools/`
+- Unit tests (CPU-only by default): `Golden Draft/tests/`
+- GPU measurement contracts and docs: `Golden Draft/docs/gpu/`
+- Ops/process docs: `Golden Draft/docs/ops/`
+
+## Branch naming
+
+Use short, intent-revealing branch names. Examples:
+
+- `feat/vra-32-gpu-probe-harness`
+- `chore/ci-v1`
+- `docs/audit-v1`
+
+## Pull request requirements
+
+Every PR should include:
+
+- **Why**: what problem this solves.
+- **What changed**: concise list of files/behavior changes.
+- **How to verify**: exact commands.
+
+And must respect these guardrails:
+
+- Do not commit run artifacts (`bench_vault/`, `logs/`, checkpoints, large binaries).
+- Keep PRs small and reversible; avoid mass refactors.
+- If a change affects measurement/stability, verify against the contract:
+  - `Golden Draft/docs/gpu/objective_contract_v1.md`
+
+Recommended verification commands:
+
+```powershell
+python -m unittest discover -s "Golden Draft/tests" -v
+python -m compileall "Golden Code" "Golden Draft"
+```
+
+## Issues, discussions, and internal tracking
+
+- **GitHub Issues** in this repo are curated **public updates** (heartbeat/bundles), not the full internal tracker.
+- For questions and design discussion, use **GitHub Discussions**.
+- Internal execution planning and backlog live in Linear (not mirrored 1:1 here).
+
+## Reproducibility
+
+If you report a number (throughput, VRAM, stability), include a minimal result packet:
+
+- commit hash
+- `env.json`
+- `workload_id`
+- full CLI args and output directory
+
+See: `Golden Draft/docs/ops/reproducibility_v1.md`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+VRAXION is a research repository. Security is still taken seriously, but expectations should match the scope.
+
+## Reporting a vulnerability
+
+If you believe you have found a security vulnerability:
+
+1) Prefer a private report via GitHub Security Advisories:
+   https://github.com/Kenessy/VRAXION/security/advisories/new
+2) If you cannot use advisories, open a GitHub Discussion and clearly mark it as a security concern.
+
+Please include:
+
+- A clear description of the issue
+- Steps to reproduce
+- Impact assessment (what could an attacker do?)
+- Any mitigations or patches you propose
+
+## In scope
+
+- Vulnerabilities that affect users running VRAXION tooling or published artifacts.
+
+## Out of scope
+
+- Issues that require secrecy for public-source code (anything public can be cloned).
+- Attacks requiring full local machine compromise.
+
+## Supported versions
+
+This repo is under active development. Only `main` is considered supported.


### PR DESCRIPTION
Why
- Make contribution/security expectations explicit and reduce messy issue intake.

What changed
- Add: CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md
- Add: .github/ISSUE_TEMPLATE/config.yml (disable blank issues; point to Discussions + Security advisories)

How to verify
- Browse the new markdown files.
- In GitHub UI, confirm Issues shows templates and blank issues are disabled.
