### PR TITLE
CI: CPU-only unittest workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  cpu-tests:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install numpy torch
+
+      - name: Compile (sanity)
+        run: |
+          python -m compileall "Golden Code" "Golden Draft"
+
+      - name: Unit tests
+        run: |
+          python -m unittest discover -s "Golden Draft/tests" -v


### PR DESCRIPTION
Why
- Add an automatic CPU-only quality gate on PRs/pushes without requiring CUDA.

What changed
- Add .github/workflows/ci.yml:
  - windows-latest
  - Python 3.11
  - installs numpy + torch
  - runs compileall + unittest

How to verify
- After opening this PR, GitHub Actions should run CI and report status.
