### PR TITLE
docs(research): import swarm/bus postmortem deep research report (2026-02-05)

### DIFF
--- a/Golden Draft/docs/research/deep_research_swarm_bus_postmortem_2026-02-05.md
+++ b/Golden Draft/docs/research/deep_research_swarm_bus_postmortem_2026-02-05.md
@@ -1,0 +1,268 @@
+---
+imported_from: "S:/AGENT B FOLDER FOR INCOMING DATA/deep-research-report (6).md"
+imported_utc: "2026-02-05T06:51:10Z"
+source_sha256: "257426DADD2B4AD6424FEF4B80C6C86CBAE0D6C39C7CCB3D9EEC5E20F2E995C4"
+repo_commit: "b91f5c4792a45e758e2b832db4203afa8ab1a6a3"
+notes: "Verbatim import; citation markers may be non-portable."
+---
+
+# Postmortem and Synthesis of the Swarm‑Bus Brainstorming
+
+## What the brainstorming actually converged on
+
+Your session started with a very concrete, “OS‑view” mental model: a long **concatenated line** of node outputs (initially 1D scalars) and the desire to make the graph *visually legible* (N1…N∞, multiple lines stacked). That quickly exposed the real architectural question: **how can a growing swarm communicate and refine without the whole system becoming bandwidth‑bound or role‑shuffled every time N changes?**
+
+By the end, you had implicitly built a coherent target architecture with three key invariants:
+
+1) **Stable semantics under growth** (“static space law”): a base coordinate system that does *not* change meaning when the swarm grows. This matches the entity["organization","VRAXION","ai research project"] project’s explicit rule: separate what is measurable/engineering from what is hypothesis; if it isn’t logged and reproducible, treat it as hypothesis. fileciteturn103file0L191-L202
+
+2) **Bounded global bandwidth**: instead of concatenating all node outputs (O(N·D) traffic), use a **fixed‑size aggregation structure** (hash/sketch “bus”) so per‑step compute/VRAM can remain bounded even if N grows.
+
+3) **Multi‑resolution capacity**: if the base bus collides (overcrowded / contested), allocate more “resolution” *locally* (paged/hierarchical bus, “add more space in an arc,” not widen the global window).
+
+The most important “local fit” you already have in code is that entity["organization","INSTNCT","memory architecture codename"] already uses a **ring address space** plus an explicit **router_map** buffer that decouples “address → expert” from naïve modulo routing. That’s the exact primitive you need for “more resolution in a specific arc.” fileciteturn110file0L589-L593
+
+So, distilled: you were not merely discussing “a second pass” or “phi skips”—you were circling a **growth‑invariant address space + bounded bus + optional local refinement pages** design.
+
+## Claim‑by‑claim evaluation of the main ideas
+
+### “Never overflow input” via fixed input width
+
+This is the one idea that **must be corrected** because it can silently poison architecture decisions: a fixed‑width vector cannot be guaranteed to “never overflow information.” What *is* achievable is **fixed interface semantics** (stable coordinate meanings) and **bounded resource usage**, not lossless representation of arbitrarily large information. This aligns strongly with the project’s own guardrail: anything not measured/benchmarked is hypothesis, not a guarantee. fileciteturn103file0L191-L202
+
+The correct engineering interpretation of your “static window” is:  
+**keep the coordinate system stable**, but allow (a) more steps through the system, (b) deeper refinement passes, or (c) paged substructures that add capacity to overloaded regions.
+
+### Golden ratio / Fibonacci spiral as an architectural necessity
+
+Two separate claims got mixed together:
+
+- The **mathematical fact**: the golden ratio is widely discussed as “maximally badly approximable” (informally “most irrational”) in the continued‑fraction sense, which makes it useful for scattering phases/angles to avoid periodic alignment. citeturn4search3  
+- The **engineering claim**: therefore it is *necessary* for your fractal bus / exponential subdivision.
+
+The second claim is **not** correct. Your refinement mechanism is a **resolution/partitioning** problem, not a botanical packing problem. If you want deterministic addressing and stable “prefix semantics,” binary/dyadic splits (powers of 2, tries, quadtrees) naturally fit hardware and stable keying.
+
+Where phi *can* be valid is as a **hysteresis constant** or “avoid resonance” heuristic—but that’s a tuning choice, not a geometric inevitability. In fact, entity["organization","INSTNCT","memory architecture codename"] already contains a **phi‑based Schmitt trigger** in the Brainstem mixer (engage/release thresholds at ~0.618/0.382). That’s an example of phi as a *controller constant*, not an addressing law. fileciteturn109file0L30-L36
+
+### Dynamic phi‑skip wiring that depends on N
+
+This is the idea that sounds elegant but breaks the most important invariant (role stability). If “who I connect to” changes when N grows, then any learned specialization tied to that wiring becomes unstable.
+
+Distributed systems solved this class of problem long ago: use stable key→node mapping with minimal disruption under membership change (consistent hashing / DHT style). The entity["people","Ion Stoica","distributed systems researcher"] et al. entity["organization","MIT CSAIL","computer science lab"] entity["organization","Chord Project","p2p lookup protocol"] Chord work formalizes key→node mapping that remains stable as nodes join/leave, with logarithmic routing overhead. citeturn1search0
+
+So: **N‑dependent wiring is viable only if semantics are anchored to stable keys** and growth causes **local remapping**, not global reshuffle.
+
+### “Three passes is the golden number”
+
+There is no universal theorem that says “3 passes is optimal.” What *is* true is that iterative inference/refinement often shows diminishing returns and can be made adaptive:
+
+- Adaptive computation schemes like entity["people","Alex Graves","machine learning researcher"] ACT let a system learn “how many internal steps” to spend per input. citeturn9search1  
+- Fixed‑point style inference like Deep Equilibrium Models frames “infinite depth” as converging to an equilibrium state (constant‑memory training via implicit differentiation). citeturn6search3turn6search2  
+- Predictive coding literature explicitly models perception as iterative error‑minimization loops (top‑down prediction, bottom‑up residual correction). citeturn6search6
+
+So, the correct stance is: **pass count is a budgeted control parameter**. You can start with 1–2 passes and add a third “integration” at slower cadence (sequence end / checkpoint) rather than per token.
+
+### “Signed hashing kills consensus”
+
+This one is half‑right but missing context.
+
+- In feature hashing, **random sign** is used to make collisions behave like unbiased random projections (reduces systematic bias). citeturn2search47  
+- In a *consensus bus* where you literally want “global mean” to remain meaningful, random signs can indeed cancel and destroy interpretability if you treat the bus as a straightforward accumulator.
+
+So the right conclusion is not “signed is always wrong,” but:  
+**signed hashing is for unbiased embedding / sketching; unsigned is for consensus‑style accumulation.** The correct choice depends on what the bus is *for*.
+
+### “Load extra experts from SSD on demand”
+
+Conceptually valid (paged capacity), but the naive implementation is a trap.
+
+Your current extracted expert router explicitly states that hibernated experts can be restored from disk, but it also states that restoration is attempted in index order “regardless of whether the current batch routes to it,” to preserve legacy side effects. fileciteturn100file0L150-L153
+
+That behavior is catastrophic for “thousands sleeping on SSD,” because it can turn every forward pass into an I/O scan. So: **paged activation must be staged**, not per‑step disk fetch, and any future “lazy restore only when used” would need a new behavior contract.
+
+## What was missing or under‑specified
+
+### You didn’t pin down “what is a node” in engineering terms
+
+Three different “node” meanings were used interchangeably:
+
+1) A “node” as an individual mini‑network/agent (ant/bee).  
+2) A “node” as an address/location on the ring (a memory slot).  
+3) A “node” as a bucket on the bus (a shared mailbox).
+
+These lead to radically different scaling laws. VRAXION already has a crisp model: a ring memory state tensor and pointer traversal, plus an “expert head” router. fileciteturn110file0L12-L20
+
+If you keep swapping node definitions, you can accidentally design something that is impossible on GPU (e.g., “every mini‑network runs every step”) while thinking you designed something like a ring pointer (only local neighborhood updated).
+
+### Participation was never formalized (and this matters because you dislike top‑k)
+
+You rejected top‑k because it “excludes most of the network.” The missing step is to define participation in measurable terms:
+
+- **Per‑step participation** is unrealistic at large N unless each node is trivial.  
+- **Participation over time** is feasible: every node receives non‑zero expected influence across a window of steps (duty cycle).
+
+Importantly, VRAXION already computes measurable proxies: expert usage counts, active expert count, max share, and normalized entropy. fileciteturn110file0L731-L752 These metrics are exactly what you need to define “meaningful participation” without requiring top‑k.
+
+### You didn’t ground bus/page decisions in the project’s determinism ethos
+
+VRAXION explicitly rejects wall‑clock dependent control loops (non‑deterministic by design). fileciteturn102file0L26-L31 It also warns that validation‑driven control loops can mask true failure modes. fileciteturn102file0L91-L94
+
+So any “dynamic auto‑loading to maintain 90% accuracy” must be done using **deterministic, logged proxies** (collision pressure, entropy collapse, loss deltas on fixed eval stream), applied at deterministic boundaries (checkpoint epochs), not “whenever the system feels it.”
+
+### The VRAM/throughput budget implications were implicit, not explicit
+
+You did bring VRAM constraints into the conversation (great), but the key dominance relation needs to be made explicit:
+
+In OD1 the dominant term is ring buffer state:  
+`ring_buf_bytes = B * synth_len * ring_len * slot_dim * bytes_per_elem(precision)` fileciteturn106file0L78-L91
+
+So “make D huge and let the bus handle it” is usually backwards: **slot_dim dominates VRAM linearly**, and you already have clear stability gates like `peak_vram_reserved_bytes <= 0.92 * total_vram_bytes`. fileciteturn107file0L54-L66
+
+Also: PyTorch’s reserved vs allocated distinction matters, because you guard on reserved. citeturn3search6
+
+## How VRAXION already supports your “ring + arc refinement + bus” direction
+
+### Growth‑invariant routing already exists in embryo: router_map + offline split/merge
+
+- `router_map` is an explicit address→expert mapping, initialized as modulo but intended to decouple routing from modulo. fileciteturn110file0L589-L593  
+- Offline mitosis exists: clone an overloaded expert and redirect selected hot addresses to the new expert. fileciteturn111file0L6-L13  
+- Offline pruning exists: remove highest‑index expert by remapping its addresses into a kept expert. fileciteturn112file0L6-L15  
+
+This is precisely “add more resolution into an arc.” An “arc” is just “a set of ring addresses.” You already have the correct lifecycle primitive: **checkpoint‑only structural edits**, which preserves determinism and makes growth auditable.
+
+### Multi‑pass mixing primitives already exist (but framed as ring modules)
+
+The AbsoluteHallway includes auxiliary rings (vault ring, think ring) and optional brainstem‑driven mixing. fileciteturn110file0L484-L542  
+The brainstem mixer uses a Schmitt trigger with hysteresis and produces a FAST/SHIELD mixing weight. fileciteturn109file0L11-L16  
+
+So VRAXION already contains the skeleton of “conscious/unconscious” style dual dynamics; it’s just implemented as *mixing controllers*, not as a philosophical pass structure.
+
+### The project already has explicit contracts for “what is stable” and “what counts as valid”
+
+- Stable workload IDs are computed from canonicalized specs hashed with SHA‑256. fileciteturn108file0L100-L118  
+- GPU runs are governed by objective + stability contracts (throughput metric, step‑time explosion checks, VRAM guard). fileciteturn107file0L25-L67  
+- The engineering/hypothesis split is explicitly documented. fileciteturn103file0L191-L202
+
+This matters because the brainstorm proposed many “self‑tuning” ideas that could easily violate determinism if not formalized.
+
+## Comparative evaluation of the communication designs you discussed
+
+### Architecture comparison table
+
+| Communication architecture | How messages move | Participation property | Growth invariance risk | Compute / memory scaling intuition | Main failure mode |
+|---|---|---|---|---|---|
+| Dense concatenation (your original line) | global vector `[m1;m2;...;mN]` | everyone always included | high (shape changes with N) | bandwidth O(N·D), global read O(N·D) | impossible bandwidth at scale, role reshuffle when N changes |
+| Fully connected attention | every node attends to every node | everyone influences everyone | medium (can be position‑encoded stable) | O(N²·D) compute, O(N²) links | quadratic blowup, oversmoothing/instability in deep message passing |
+| Top‑k MoE routing (rejected) | only k experts active per sample | excluded per‑step, but can be balanced over time | medium (depends on router) | compute ~O(k) experts per sample | starvation/collapse unless load‑balancing, plus your inclusion objection |
+| Single fixed sketch/hash bus | nodes write/read a fixed `[M,D]` bus | everyone can write, limited read | low (if keyed by stable IDs) | O(N·k_write·D) writes, O(N·k_read·D) reads; bus mem O(M·D) | collisions/interference if M too small; blur if too mixing‑heavy |
+| Paged / hierarchical bus (your “resolution levels”) | bus0 + optional per‑region pages | everyone writes bus0; pages add local capacity | low if pages keyed and created deterministically | base bounded + page budgeted | paging policy errors, semantic drift if remapping not minimized |
+| Ring‑pointer traversal with arc splits (VRAXION‑native) | pointer updates local neighborhood; router_map partitions arcs | not everyone per step, but duty‑cycle over time | very low if router_map edits are local | compute per step mostly local; memory dominated by ring buffers | hotspots if arcs too wide; needs split criteria |
+
+### Why oversmoothing showed up implicitly (and why it matters)
+
+Deep message‑passing systems tend to homogenize representations (“oversmoothing”) when repeatedly mixing neighbor information; this is known in graph neural nets and dynamical analyses. citeturn7search5turn5search9
+
+Your intuition (avoid blur, keep sharp binding) matches VRAXION’s own notes: phase‑lag mixing and blur‑like controls were explicitly flagged as likely harmful to current binding experiments. fileciteturn102file0L26-L28
+
+So any bus mechanism must preserve **binding** and prevent “everything becomes global soup.” Hash bucketization (M>1), controlled write magnitudes, and selective *resolution allocation* are the way to keep global sharing without collapse.
+
+## Ultimate proposed solution
+
+### The solution in one sentence
+
+Use a **growth‑invariant ring address space** as the stable “world coordinates,” route communication through a **fixed‑size sketch bus** for bounded global context, and increase capacity by **deterministic arc‑splitting** (router_map + offline mitosis) plus optional **paged sub‑buses** for hotspots—while measuring participation and collision pressure using the telemetry primitives VRAXION already computes.
+
+### The concrete blueprint
+
+#### Stable coordinate system
+
+- The immutable “space” is the ring address space already used by INSTNCT. This gives you “static space law” in a literal engineering form: an address means the same thing across growth, because you don’t renumber the world—only refine who owns which arc. fileciteturn110file0L589-L593  
+- If you later want 2D/3D “windows,” map them into ring addresses through a locality‑preserving code (Morton/Z‑order or Hilbert). Do not base semantics on phi; use dyadic/prefix splits so the address can be refined by adding bits.
+
+#### Communication bus (bounded bandwidth, no top‑k exclusion)
+
+Maintain an always‑on bus:
+
+- `bus0` shape `[M0, D_bus]` in fp16/bf16.  
+- Every active node writes into `k_write` buckets determined by a stable hash of `(node_id, context_key, j)`; every node also reads `k_read` buckets based on `(node_id, context_key, j)`.
+
+This is “everyone participates” at the bus level, but bandwidth stays controlled because each writer touches only O(k) buckets.
+
+To ground it in known theory: a sketch is a small‑space summary that answers approximate queries over a large stream; Count‑Min Sketch formalizes this type of tradeoff (space vs error). citeturn1search1  
+Feature hashing similarly explains why collisions can be acceptable and how signed hashing affects bias. citeturn2search47
+
+#### Multi‑resolution “add more space in an arc” mechanism
+
+You already have the correct growth primitive for arcs:
+
+- Choose a hotspot criterion (see below), then run offline mitosis: clone parent expert weights and redirect selected ring addresses into the new expert via router_map edits. fileciteturn111file0L6-L13  
+- Optionally prune later with offline merge to keep expert IDs dense. fileciteturn112file0L6-L15  
+
+This yields your desired phenomenon: the overall coordinate space stays fixed, but overloaded arcs get more capacity (“more resolution”), exactly like paging a finer map.
+
+If you want true “paged bus” levels as well, treat each coarse arc as optionally having a resident page:
+
+- `page[b0].bus1` shape `[M1, D_bus]`, only for selected arcs.
+- Pages are created/expanded at deterministic boundaries (checkpoint epochs), not per step, to preserve throughput stability and reproducibility (matching VRAXION’s anti wall‑clock ethos). fileciteturn102file0L26-L31
+
+#### Pass structure that matches your “conscious/unconscious” intuition without confusing it with backprop
+
+Define passes as **operational inference cycles**, not gradient backprop:
+
+- Pass A (fast / “instinct”): pointer traversal + local update + bus0 write/read once.  
+- Pass B (reflect / “check”): a second lightweight application of bus context to adjust gating/pointer update strength (still bounded).  
+- Pass C (integration): does **not** run per token; it is checkpoint‑time: analyze telemetry and commit structural growth (mitosis/prune + page promotion).
+
+This is the cleanest way to preserve your multi‑pass intuition while aligning with the GPU stability contracts (per‑step throughput and step‑time explosion gates). fileciteturn107file0L54-L66  
+If you later want variable pass count, ACT is a reference pattern for learning “compute when needed,” but you should only introduce it once determinism and measurement are locked. citeturn9search1
+
+#### Hotspot / “needs more resolution” signals that are deterministic and already measurable
+
+Do not define hotspot as “top 10% of vector dimensions.” Define hotspot as **contention / collapse** in a region:
+
+- Expert usage collapse: low normalized entropy, high max‑share. VRAXION already logs these stats. fileciteturn110file0L731-L752  
+- Step entropy proxy used by BrainstemMixer is already computed from mapped expert IDs. fileciteturn110file0L753-L775  
+- Bus collision pressure: approximate “how many distinct writers hit this bucket” plus bucket magnitude saturation. If you want a canonical sketch reference for “small summary, approximate query,” Count‑Min is the right conceptual anchor. citeturn1search1
+
+#### Hardware reality constraints (so the design doesn’t die on VRAM)
+
+- The ring buffer term dominates VRAM and scales linearly with slot_dim, ring_len, batch, and sequence length. fileciteturn106file0L78-L91  
+- Therefore: keep `D_bus` modest (e.g., 16–64) and keep bus M small enough that bus memory is negligible compared to ring state, especially under WDDM. fileciteturn106file0L168-L179  
+- Keep guarding on reserved memory, not allocated, consistent with PyTorch’s caching allocator semantics. citeturn3search6 and VRAXION’s own VRAM guard definition. fileciteturn107file0L64-L66  
+
+#### What to do about “automatic self‑loading to maintain 90% accuracy”
+
+You can get the behavior you want (“system meets target quality with minimal experts”) but only if you avoid the two explicitly documented traps:
+
+- Do **not** make the control loop depend on wall‑clock jitter (rejected as non‑deterministic). fileciteturn102file0L26-L31  
+- Be cautious with validation‑driven moving thresholds; it can mask true failure modes. fileciteturn102file0L91-L94  
+
+The deterministic version is:
+
+- Fix a reproducible evaluation stream (stable workload_id) fileciteturn108file0L100-L118  
+- Decide a fixed policy: “if collision pressure or entropy collapse exceeds threshold for H steps, schedule a split/page at next checkpoint.”  
+- Commit changes offline (mitosis/prune), so growth is auditable and reversible.
+
+That gives you “automatic behavior” without “runtime chaos.”
+
+### Direct answer to your last question: “use a ring look for the hashmap adding more resolution into a specific arc?”
+
+Yes—and it is not just a metaphor in VRAXION, it is already the native mechanism:
+
+- The ring address space is your stable “window.”  
+- An “arc” is a set of addresses.  
+- Increasing resolution in an arc is exactly “redirect these addresses to a new expert/page,” which router_map + offline mitosis implements. fileciteturn110file0L589-L593 fileciteturn111file0L6-L13  
+
+That approach is also aligned with the well‑studied principle of minimizing remapping during growth (DHT/consistent hashing style), rather than changing global geometry when membership changes. citeturn1search0
+
+## My ultimate version of the architecture
+
+I would implement **Fractal Arc Paging over a Shared Sketch Bus**:
+
+- **Base (always on):** ring pointer memory + bus0 `[M0,D_bus]` (everyone writes/reads a few hashed buckets; no top‑k exclusion).  
+- **Local refinement:** deterministic arc splits using router_map + offline mitosis/prune (adds capacity only where needed, without semantic reshuffle).  
+- **Optional pages:** per‑arc bus pages that are activated at checkpoint boundaries and kept within a strict resident budget (avoids SSD‑fetch per step, avoids WDDM stalls).  
+- **Passes:** 2 per‑token inference passes max (fast + reflect), plus a checkpoint‑time integration pass that decides splits/pages using already‑logged telemetry.  
+- **Stability:** all growth decisions driven by deterministic counters (entropy/max‑share/collision pressure), constrained by the existing VRAM/step‑time stability contract. fileciteturn107file0L54-L66
+
+This preserves your core values—**no global reshuffle, bounded bandwidth, everyone participates over time, and resolution grows where the world demands it**—while staying inside the project’s explicit reproducibility discipline. fileciteturn103file0L191-L202


### PR DESCRIPTION
Imports incoming deep research report into repo under Golden Draft/docs/research/ with integrity metadata (source path + sha256 + repo commit + timestamp).\n\n- Source sha256: 257426DADD2B4AD6424FEF4B80C6C86CBAE0D6C39C7CCB3D9EEC5E20F2E995C4\n- Notes: report preserved verbatim; citation markers may be non-portable.\n\nWiki contains the human-readable intake; this PR is the archival artifact only.\n\nNo code changes.