### PR TITLE
tools: honor VRX_EXPERT_HEADS in draft runners

### DIFF
--- a/Golden Draft/tests/test_expert_heads_checkpoint_keys.py
+++ b/Golden Draft/tests/test_expert_heads_checkpoint_keys.py
@@ -1,0 +1,44 @@
+"""Behavior locks for EXPERT_HEADS-driven checkpoint layouts."""
+
+from __future__ import annotations
+
+import unittest
+
+import conftest  # noqa: F401  (import side-effect: sys.path bootstrap)
+
+
+class ExpertHeadsCheckpointKeyTests(unittest.TestCase):
+    def test_state_dict_uses_expert_heads_layout_when_enabled(self) -> None:
+        with conftest.temporary_env(
+            VRX_EXPERT_HEADS="2",
+            VRX_RING_LEN="8",
+            VRX_SLOT_DIM="16",
+            VRX_SENSORY_RING="0",
+            VRX_VAULT="0",
+            VRX_THINK_RING="0",
+            VRX_NAN_GUARD=None,
+        ):
+            from vraxion.instnct import seed as seed_mod
+
+            seed_mod.EXPERT_HEADS = 2
+
+            from tools import instnct_runner
+
+            ctx = instnct_runner.default_context()
+            model = ctx.model_ctor(
+                input_dim=1,
+                num_classes=2,
+                ring_len=ctx.ring_len,
+                slot_dim=ctx.slot_dim,
+            ).cpu()
+
+            keys = list(model.state_dict().keys())
+
+            self.assertTrue(any(key.startswith("head.experts.0.") for key in keys), "missing head.experts.0.* keys")
+            self.assertTrue(any(key.startswith("head.experts.1.") for key in keys), "missing head.experts.1.* keys")
+            self.assertFalse(any(key.startswith("head.single.") for key in keys), "unexpected head.single.* keys present")
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/Golden Draft/tools/eval_only.py
+++ b/Golden Draft/tools/eval_only.py
@@ -128,9 +128,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     try:
         import torch
+        from vraxion.instnct import absolute_hallway as hallway_mod
         from vraxion.instnct.absolute_hallway import AbsoluteHallway
         from vraxion.instnct import infra
         from vraxion.instnct import modular_checkpoint as mckpt
+        from vraxion.instnct import seed as seed_mod
         from vraxion.settings import load_settings
 
         from tools import instnct_data, instnct_eval
@@ -152,6 +154,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         # Keep infra in sync with settings-driven paths.
         infra.ROOT = str(cfg.root)
         infra.LOG_PATH = str(cfg.log_path)
+
+        moddir_pre = mckpt._resolve_modular_resume_dir(str(ckppth))
+        if moddir_pre:
+            seed_mod._maybe_override_expert_heads(str(moddir_pre))
+        hallway_mod.EXPERT_HEADS = int(seed_mod.EXPERT_HEADS)
 
         # Build a deterministic eval loader. For now we always use a subset
         # of the training dataset (no torchvision requirement).

--- a/Golden Draft/tools/instnct_runner.py
+++ b/Golden Draft/tools/instnct_runner.py
@@ -213,6 +213,9 @@ def main(*, ctx: Optional[InstnctRunnerContext] = None) -> None:
     ctx.set_seed(ctx.seed)
     if ctx.resume:
         ctx.maybe_override_expert_heads(os.path.abspath(ctx.checkpoint_path))
+        from vraxion.instnct import absolute_hallway, seed as seed_mod
+
+        absolute_hallway.EXPERT_HEADS = int(seed_mod.EXPERT_HEADS)
 
     # Reduce kernel search overhead / variance.
     try:
@@ -351,13 +354,14 @@ def default_context() -> InstnctRunnerContext:
             continue
 
     from vraxion.settings import load_settings
-    from vraxion.instnct import infra
+    from vraxion.instnct import absolute_hallway, infra, seed as seed_mod
     from vraxion.instnct.absolute_hallway import AbsoluteHallway
     from vraxion.instnct.seed import _maybe_override_expert_heads, set_seed
 
     from . import instnct_data, instnct_eval, instnct_train_steps, instnct_train_wallclock
 
     cfg = load_settings()
+    absolute_hallway.EXPERT_HEADS = int(seed_mod.EXPERT_HEADS)
 
     # Keep infra in sync with settings-driven paths.
     infra.ROOT = str(cfg.root)


### PR DESCRIPTION
Wires absolute_hallway.EXPERT_HEADS from seed.EXPERT_HEADS in Golden Draft entrypoints (instnct_runner + eval_only), so VRX_EXPERT_HEADS controls head.single vs head.experts checkpoint layout. Adds CPU regression test.