### PR TITLE
tools: gate mitosis telemetry with VRX_MITOSIS

### DIFF
--- a/Golden Draft/tests/test_mitosis_env_flag.py
+++ b/Golden Draft/tests/test_mitosis_env_flag.py
@@ -1,0 +1,30 @@
+"""Behavior locks for VRX_MITOSIS environment gating."""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+import conftest  # noqa: F401  (import side-effect: sys.path bootstrap)
+
+from tools import env_utils
+
+
+class MitosisEnvFlagTests(unittest.TestCase):
+    def test_env_is_one_parses_strictly(self) -> None:
+        with conftest.temporary_env(VRX_MITOSIS=None):
+            self.assertFalse(env_utils.env_is_one(os.environ, "VRX_MITOSIS"))
+
+        with conftest.temporary_env(VRX_MITOSIS="0"):
+            self.assertFalse(env_utils.env_is_one(os.environ, "VRX_MITOSIS"))
+
+        with conftest.temporary_env(VRX_MITOSIS="1"):
+            self.assertTrue(env_utils.env_is_one(os.environ, "VRX_MITOSIS"))
+
+        with conftest.temporary_env(VRX_MITOSIS="true"):
+            self.assertFalse(env_utils.env_is_one(os.environ, "VRX_MITOSIS"))
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/Golden Draft/tools/env_utils.py
+++ b/Golden Draft/tools/env_utils.py
@@ -84,6 +84,13 @@ def parse_bool(
     return default, msg
 
 
+def env_is_one(env: Mapping[str, str], key: str) -> bool:
+    """Return True iff env[key] is exactly the string "1" (after stripping)."""
+
+    raw = env.get(key)
+    return raw is not None and raw.strip() == "1"
+
+
 def env_bool(
     env: Mapping[str, str],
     key: str,

--- a/Golden Draft/tools/eval_only.py
+++ b/Golden Draft/tools/eval_only.py
@@ -133,7 +133,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         from vraxion.instnct import modular_checkpoint as mckpt
         from vraxion.settings import load_settings
 
-        from tools import instnct_data, instnct_eval
+        from tools import env_utils, instnct_data, instnct_eval
     except Exception as exc:
         _eprint(f"[eval_only] ERROR: missing required dependency: {exc}")
         if argobj.debug:
@@ -265,7 +265,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             log=infra.log,
             synth_mode=str(getattr(cfg, "synth_mode", "")),
             mi_shuffle=bool(getattr(cfg, "mi_shuffle", False)),
-            mitosis_enabled=bool(getattr(cfg, "mitosis_enabled", False)),
+            mitosis_enabled=env_utils.env_is_one(os.environ, "VRX_MITOSIS"),
         )
 
         model.eval()
@@ -283,4 +283,3 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/Golden Draft/tools/instnct_runner.py
+++ b/Golden Draft/tools/instnct_runner.py
@@ -355,7 +355,7 @@ def default_context() -> InstnctRunnerContext:
     from vraxion.instnct.absolute_hallway import AbsoluteHallway
     from vraxion.instnct.seed import _maybe_override_expert_heads, set_seed
 
-    from . import instnct_data, instnct_eval, instnct_train_steps, instnct_train_wallclock
+    from . import env_utils, instnct_data, instnct_eval, instnct_train_steps, instnct_train_wallclock
 
     cfg = load_settings()
 
@@ -371,7 +371,7 @@ def default_context() -> InstnctRunnerContext:
         log=infra.log,
         synth_mode=str(getattr(cfg, "synth_mode", "")),
         mi_shuffle=bool(getattr(cfg, "mi_shuffle", False)),
-        mitosis_enabled=bool(getattr(cfg, "mitosis_enabled", False)),
+        mitosis_enabled=env_utils.env_is_one(os.environ, "VRX_MITOSIS"),
     )
 
     evo_cfg = EvolutionConfig(


### PR DESCRIPTION
Replaces cfg.mitosis_enabled (non-existent) with strict env gating: VRX_MITOSIS=1 enables mitosis telemetry; default remains off. Adds env_utils.env_is_one() helper + regression test.