### PR TITLE
tools: add vrx_sync.ps1 wrapper for Linear key file

### DIFF
--- a/Golden Draft/tools/vrx_sync.ps1
+++ b/Golden Draft/tools/vrx_sync.ps1
@@ -1,0 +1,42 @@
+[CmdletBinding()]
+param(
+    # Pass-through args for vrx_sync_linear_projects.py, e.g.:
+    #   .\vrx_sync.ps1 sync --apply
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$Args
+)
+
+$ErrorActionPreference = "Stop"
+
+# Secrets policy:
+# - This script NEVER prints the Linear API key.
+# - Store the key outside the repo (recommended) or point to a file via VRX_LINEAR_API_KEY_FILE.
+#
+# Default key file location:
+#   %USERPROFILE%\.vraxion\secrets\linear_api_key.txt
+
+$keyFile = $env:VRX_LINEAR_API_KEY_FILE
+if ([string]::IsNullOrWhiteSpace($keyFile)) {
+    $keyFile = Join-Path $HOME ".vraxion\secrets\linear_api_key.txt"
+}
+
+if (-not (Test-Path -LiteralPath $keyFile)) {
+    Write-Error ("Linear API key file not found: {0}`n" -f $keyFile) `
+        + "Set VRX_LINEAR_API_KEY_FILE to an existing file, or create:`n" `
+        + (Join-Path $HOME ".vraxion\secrets\linear_api_key.txt")
+    exit 2
+}
+
+$env:LINEAR_API_KEY = (Get-Content -LiteralPath $keyFile -Raw).Trim()
+if ([string]::IsNullOrWhiteSpace($env:LINEAR_API_KEY)) {
+    Write-Error ("Linear API key file is empty: {0}" -f $keyFile)
+    exit 2
+}
+
+$scriptPath = Join-Path $PSScriptRoot "vrx_sync_linear_projects.py"
+if (-not (Test-Path -LiteralPath $scriptPath)) {
+    Write-Error ("Missing sync script: {0}" -f $scriptPath)
+    exit 2
+}
+
+python $scriptPath @Args


### PR DESCRIPTION
Adds a PowerShell wrapper that reads the Linear API key from a local file (default: `%USERPROFILE%\.vraxion\secrets\linear_api_key.txt`) and runs `vrx_sync_linear_projects.py` without printing the key.

Why: enables repeatable Linear -> GitHub Projects sync without manual JSON export.

How to verify:
- `pwsh -NoProfile -File "Golden Draft/tools/vrx_sync.ps1" sync --help`
- `pwsh -NoProfile -File "Golden Draft/tools/vrx_sync.ps1" sync --apply`

No secrets are committed.
