### PR TITLE
VRA-35: OD1 capacity model v1 (calibration JSON + estimators)

### DIFF
--- a/Golden Draft/tests/test_fit_gpu_capacity_model.py
+++ b/Golden Draft/tests/test_fit_gpu_capacity_model.py
@@ -1,0 +1,164 @@
+"""VRA-35 tests: fit_gpu_capacity_model (CPU-only)."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import conftest  # noqa: F401  (import side-effect: sys.path bootstrap)
+
+from tools import fit_gpu_capacity_model
+
+
+def _write_json(path: Path, obj: object) -> None:
+    path.write_text(json.dumps(obj, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _mk_run(
+    root: Path,
+    name: str,
+    *,
+    ant_path: str,
+    colony_path: str,
+    batch: int,
+    alloc: int,
+    reserved: int,
+    stability_pass: bool,
+    fail_reasons: list[str] | None = None,
+    measure_steps: int = 50,
+    precision: str = "fp16",
+    amp: int = 1,
+    out_dim: int = 1,
+    total_vram_bytes: int = 1000,
+) -> None:
+    run_dir = root / name
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    run_cmd = {
+        "argv": [
+            "Golden Draft\\tools\\gpu_capacity_probe.py",
+            "--ant",
+            ant_path,
+            "--colony",
+            colony_path,
+            "--out-dim",
+            str(out_dim),
+            "--batch",
+            str(batch),
+            "--measure-steps",
+            str(measure_steps),
+        ],
+        "canonical_spec": {
+            "schema_version": "workload_schema_v1",
+            "ant_spec": {"ring_len": 32, "slot_dim": 16, "ptr_dtype": "fp64", "precision": precision},
+            "colony_spec": {
+                "seq_len": 8,
+                "synth_len": 8,
+                "batch_size": batch,
+                "ptr_update_every": 1,
+                "state_loop_samples": 0,
+            },
+        },
+    }
+    _write_json(run_dir / "run_cmd.txt", run_cmd)
+
+    metrics = {
+        "batch_size": batch,
+        "precision": precision,
+        "amp": amp,
+        "out_dim": out_dim,
+        "measure_steps": measure_steps,
+        "peak_vram_allocated_bytes": alloc,
+        "peak_vram_reserved_bytes": reserved,
+        "stability_pass": stability_pass,
+        "had_oom": False,
+        "had_nan": False,
+        "had_inf": False,
+        "fail_reasons": fail_reasons or ([] if stability_pass else ["vram_guard"]),
+    }
+    _write_json(run_dir / "metrics.json", metrics)
+
+    env = {
+        "total_vram_bytes": total_vram_bytes,
+        "gpu_name": "TEST_GPU",
+        "driver_version": "x",
+        "torch_version": "y",
+        "os": "test",
+    }
+    _write_json(run_dir / "env.json", env)
+
+
+class TestFitGpuCapacityModel(unittest.TestCase):
+    def test_deterministic_fit_and_skips_incomplete(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "runs"
+            root.mkdir(parents=True, exist_ok=True)
+
+            _mk_run(
+                root,
+                "c2_realxreal_B01_ms50",
+                ant_path="Golden Draft\\workloads\\od1_real_v1.json",
+                colony_path="Golden Draft\\workloads\\od1_real_v1.json",
+                batch=1,
+                alloc=100,
+                reserved=120,
+                stability_pass=True,
+            )
+            _mk_run(
+                root,
+                "c2_realxreal_B02_ms50",
+                ant_path="Golden Draft\\workloads\\od1_real_v1.json",
+                colony_path="Golden Draft\\workloads\\od1_real_v1.json",
+                batch=2,
+                alloc=130,
+                reserved=155,
+                stability_pass=True,
+            )
+            _mk_run(
+                root,
+                "c2_realxreal_B03_ms50_fail",
+                ant_path="Golden Draft\\workloads\\od1_real_v1.json",
+                colony_path="Golden Draft\\workloads\\od1_real_v1.json",
+                batch=3,
+                alloc=160,
+                reserved=950,
+                stability_pass=False,
+                fail_reasons=["vram_guard"],
+            )
+            # Incomplete run (should be ignored).
+            (root / "incomplete").mkdir()
+            (root / "incomplete" / "run_cmd.txt").write_text("{}", encoding="utf-8")
+
+            model1 = fit_gpu_capacity_model.fit_capacity_model_v1(
+                runs_root=root,
+                guard_ratio=0.92,
+                safe_start_ratio=0.85,
+                guard_basis="reserved",
+                measure_steps=50,
+            )
+            model2 = fit_gpu_capacity_model.fit_capacity_model_v1(
+                runs_root=root,
+                guard_ratio=0.92,
+                safe_start_ratio=0.85,
+                guard_basis="reserved",
+                measure_steps=50,
+            )
+
+            self.assertEqual(json.dumps(model1, sort_keys=True), json.dumps(model2, sort_keys=True))
+            self.assertEqual(model1["schema_version"], "capacity_model_v1")
+            self.assertEqual(model1["guard_basis"], "reserved")
+            self.assertEqual(model1["track"]["out_dim"], 1)
+            self.assertEqual(model1["track"]["precision"], "fp16")
+            self.assertEqual(model1["track"]["amp"], 1)
+
+            combos = model1["combos"]
+            self.assertEqual(len(combos), 1)
+            combo = combos[0]
+            self.assertEqual(combo["combo_name"], "C2_realxreal")
+            self.assertEqual(combo["measured_max_batch"], 2)
+            self.assertEqual(combo["boundary_fail_batch"], 3)
+            self.assertEqual(combo["base_alloc_bytes"], 70)  # 100 - 30*1
+            self.assertEqual(combo["per_batch_alloc_bytes"], 30)
+

--- a/Golden Draft/tests/test_gpu_capacity_model.py
+++ b/Golden Draft/tests/test_gpu_capacity_model.py
@@ -1,0 +1,53 @@
+"""VRA-35 tests: gpu_capacity_model estimators (CPU-only)."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import conftest  # noqa: F401  (import side-effect: sys.path bootstrap)
+
+from tools import gpu_capacity_model
+
+
+class TestGpuCapacityModel(unittest.TestCase):
+    def test_max_safe_monotonic_and_out_dim_guard(self) -> None:
+        model = {
+            "schema_version": "capacity_model_v1",
+            "guard_basis": "reserved",
+            "guard_ratio": 0.92,
+            "safe_start_ratio": 0.85,
+            "track": {"out_dim": 1, "precision": "fp16", "amp": 1},
+            "calibrated_on": {"gpu_name": "TEST_GPU", "total_vram_bytes": 1000},
+            "overhead_bytes": 5,
+            "combos": [
+                {
+                    "combo_name": "C2_realxreal",
+                    "combo_key": "combo_v1_deadbeefcafe",
+                    "combo_spec_no_batch": {},
+                    "base_alloc_bytes": 100,
+                    "per_batch_alloc_bytes": 10,
+                    "measured_max_batch": None,
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "m.json"
+            p.write_text(json.dumps(model, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+            m = gpu_capacity_model.load_capacity_model(p)
+            m.assert_track_compatible(out_dim=1)
+
+            max90 = m.estimate_max_batch("combo_v1_deadbeefcafe", guard_ratio=0.90, total_vram_bytes=1000)
+            max92 = m.estimate_max_batch("combo_v1_deadbeefcafe", guard_ratio=0.92, total_vram_bytes=1000)
+            self.assertGreaterEqual(max92, max90)
+
+            safe = m.estimate_safe_start_batch("combo_v1_deadbeefcafe", total_vram_bytes=1000)
+            self.assertLessEqual(safe, max92)
+
+            with self.assertRaises(gpu_capacity_model.CapacityModelError):
+                m.assert_track_compatible(out_dim=2)
+

--- a/Golden Draft/tools/capacity_model_v1.json
+++ b/Golden Draft/tools/capacity_model_v1.json
@@ -1,0 +1,256 @@
+{
+  "calibrated_on": {
+    "driver_version": "591.74",
+    "gpu_name": "NVIDIA GeForce RTX 4070 Ti SUPER",
+    "os": "Windows-10-10.0.26200-SP0",
+    "torch_version": "2.5.1+cu121",
+    "total_vram_bytes": 17170956288
+  },
+  "combos": [
+    {
+      "ant_path": "Golden Draft\\workloads\\od1_small_v1.json",
+      "base_alloc_bytes": 31325696,
+      "boundary_fail_batch": 29,
+      "boundary_fail_reasons": [
+        "step_time_explosion",
+        "vram_guard"
+      ],
+      "colony_path": "Golden Draft\\workloads\\od1_real_v1.json",
+      "combo_key": "combo_v1_91710b8befec",
+      "combo_name": "C1_smallxreal",
+      "combo_spec_no_batch": {
+        "ant_spec": {
+          "precision": "fp16",
+          "ptr_dtype": "fp64",
+          "ring_len": 2048,
+          "slot_dim": 256
+        },
+        "colony_spec": {
+          "ptr_update_every": 1,
+          "seq_len": 256,
+          "state_loop_samples": 0,
+          "synth_len": 256
+        },
+        "schema_version": "workload_schema_v1"
+      },
+      "fit_points": [
+        {
+          "alloc": 8792096256,
+          "batch": 16,
+          "reserved": 8820621312,
+          "run_dir": "Golden Draft/bench_vault/_tmp/vra35_capacity_model_v1/20260205_224622/c1_smallxreal_B16_fp16_amp1_E1_ms50_cal"
+        },
+        {
+          "alloc": 13172481536,
+          "batch": 24,
+          "reserved": 13201571840,
+          "run_dir": "Golden Draft/bench_vault/_tmp/vra35_capacity_model_v1/20260205_224622/c1_smallxreal_B24_fp16_amp1_E1_ms50_cal"
+        }
+      ],
+      "measured_max_batch": 28,
+      "pass_runs": [
+        {
+          "alloc": 8792096256,
+          "batch": 16,
+          "reserved": 8820621312,
+          "run_dir": "Golden Draft/bench_vault/_tmp/vra35_capacity_model_v1/20260205_224622/c1_smallxreal_B16_fp16_amp1_E1_ms50_cal"
+        },
+        {
+          "alloc": 13172481536,
+          "batch": 24,
+          "reserved": 13201571840,
+          "run_dir": "Golden Draft/bench_vault/_tmp/vra35_capacity_model_v1/20260205_224622/c1_smallxreal_B24_fp16_amp1_E1_ms50_cal"
+        },
+        {
+          "alloc": 15363526144,
+          "batch": 28,
+          "reserved": 15372124160,
+          "run_dir": "Golden Draft/bench_vault/_tmp/vra35_capacity_model_v1/20260205_224622/c1_smallxreal_B28_fp16_amp1_E1_ms50_boundary"
+        }
+      ],
+      "per_batch_alloc_bytes": 547548160
+    },
+    {
+      "ant_path": "Golden Draft\\workloads\\od1_real_v1.json",
+      "base_alloc_bytes": 62436352,
+      "boundary_fail_batch": 4,
+      "boundary_fail_reasons": [
+        "heartbeat_stall"
+      ],
+      "colony_path": "Golden Draft\\workloads\\od1_real_v1.json",
+      "combo_key": "combo_v1_33ffd4841493",
+      "combo_name": "C2_realxreal",
+      "combo_spec_no_batch": {
+        "ant_spec": {
+          "precision": "fp16",
+          "ptr_dtype": "fp64",
+          "ring_len": 8192,
+          "slot_dim": 576
+        },
+        "colony_spec": {
+          "ptr_update_every": 1,
+          "seq_len": 256,
+          "state_loop_samples": 0,
+          "synth_len": 256
+        },
+        "schema_version": "workload_schema_v1"
+      },
+      "fit_points": [
+        {
+          "alloc": 4932603904,
+          "batch": 1,
+          "reserved": 4949278720,
+          "run_dir": "Golden Draft/bench_vault/_tmp/vra35_capacity_model_v1/20260205_224622/c2_realxreal_B01_fp16_amp1_E1_ms50_r1"
+        },
+        {
+          "alloc": 9802771456,
+          "batch": 2,
+          "reserved": 9837740032,
+          "run_dir": "Golden Draft/bench_vault/_tmp/vra35_capacity_model_v1/20260205_224622/c2_realxreal_B02_fp16_amp1_E1_ms50_cal"
+        }
+      ],
+      "measured_max_batch": 3,
+      "pass_runs": [
+        {
+          "alloc": 4932603904,
+          "batch": 1,
+          "reserved": 4949278720,
+          "run_dir": "Golden Draft/bench_vault/_tmp/vra35_capacity_model_v1/20260205_224622/c2_realxreal_B01_fp16_amp1_E1_ms50_r1"
+        },
+        {
+          "alloc": 4932603904,
+          "batch": 1,
+          "reserved": 4949278720,
+          "run_dir": "Golden Draft/bench_vault/_tmp/vra35_capacity_model_v1/20260205_224622/c2_realxreal_B01_fp16_amp1_E1_ms50_r2"
+        },
+        {
+          "alloc": 9802771456,
+          "batch": 2,
+          "reserved": 9837740032,
+          "run_dir": "Golden Draft/bench_vault/_tmp/vra35_capacity_model_v1/20260205_224622/c2_realxreal_B02_fp16_amp1_E1_ms50_cal"
+        },
+        {
+          "alloc": 14673004544,
+          "batch": 3,
+          "reserved": 14726201344,
+          "run_dir": "Golden Draft/bench_vault/_tmp/vra35_capacity_model_v1/20260205_224622/c2_realxreal_B03_fp16_amp1_E1_ms50_boundary"
+        }
+      ],
+      "per_batch_alloc_bytes": 4870167552
+    },
+    {
+      "ant_path": "Golden Draft\\workloads\\od1_stress_v1.json",
+      "base_alloc_bytes": null,
+      "boundary_fail_batch": 2,
+      "boundary_fail_reasons": [
+        "vram_guard"
+      ],
+      "colony_path": "Golden Draft\\workloads\\od1_real_v1.json",
+      "combo_key": "combo_v1_c44773c25176",
+      "combo_name": "C3_stressxreal",
+      "combo_spec_no_batch": {
+        "ant_spec": {
+          "precision": "fp16",
+          "ptr_dtype": "fp64",
+          "ring_len": 16384,
+          "slot_dim": 768
+        },
+        "colony_spec": {
+          "ptr_update_every": 1,
+          "seq_len": 256,
+          "state_loop_samples": 0,
+          "synth_len": 256
+        },
+        "schema_version": "workload_schema_v1"
+      },
+      "fit_points": [
+        {
+          "alloc": 13051600896,
+          "batch": 1,
+          "reserved": 13100908544,
+          "run_dir": "Golden Draft/bench_vault/_tmp/vra35_capacity_model_v1/20260205_224622/c3_stressxreal_B01_fp16_amp1_E1_ms50_cal"
+        }
+      ],
+      "measured_max_batch": 1,
+      "pass_runs": [
+        {
+          "alloc": 13051600896,
+          "batch": 1,
+          "reserved": 13100908544,
+          "run_dir": "Golden Draft/bench_vault/_tmp/vra35_capacity_model_v1/20260205_224622/c3_stressxreal_B01_fp16_amp1_E1_ms50_cal"
+        }
+      ],
+      "per_batch_alloc_bytes": null
+    },
+    {
+      "ant_path": "Golden Draft\\workloads\\od1_real_v1.json",
+      "base_alloc_bytes": 59368448,
+      "boundary_fail_batch": 7,
+      "boundary_fail_reasons": [
+        "step_time_explosion",
+        "vram_guard"
+      ],
+      "colony_path": "Golden Draft\\workloads\\od1_small_v1.json",
+      "combo_key": "combo_v1_97ad611a1d57",
+      "combo_name": "C4_realxsmall",
+      "combo_spec_no_batch": {
+        "ant_spec": {
+          "precision": "fp16",
+          "ptr_dtype": "fp64",
+          "ring_len": 8192,
+          "slot_dim": 576
+        },
+        "colony_spec": {
+          "ptr_update_every": 1,
+          "seq_len": 128,
+          "state_loop_samples": 0,
+          "synth_len": 128
+        },
+        "schema_version": "workload_schema_v1"
+      },
+      "fit_points": [
+        {
+          "alloc": 9837215744,
+          "batch": 4,
+          "reserved": 9909043200,
+          "run_dir": "Golden Draft/bench_vault/_tmp/vra35_capacity_model_v1/20260205_224622/c4_realxsmall_B04_fp16_amp1_E1_ms50_cal"
+        },
+        {
+          "alloc": 14726139392,
+          "batch": 6,
+          "reserved": 14835253248,
+          "run_dir": "Golden Draft/bench_vault/_tmp/vra35_capacity_model_v1/20260205_224622/c4_realxsmall_B06_fp16_amp1_E1_ms50_cal"
+        }
+      ],
+      "measured_max_batch": 6,
+      "pass_runs": [
+        {
+          "alloc": 9837215744,
+          "batch": 4,
+          "reserved": 9909043200,
+          "run_dir": "Golden Draft/bench_vault/_tmp/vra35_capacity_model_v1/20260205_224622/c4_realxsmall_B04_fp16_amp1_E1_ms50_cal"
+        },
+        {
+          "alloc": 14726139392,
+          "batch": 6,
+          "reserved": 14835253248,
+          "run_dir": "Golden Draft/bench_vault/_tmp/vra35_capacity_model_v1/20260205_224622/c4_realxsmall_B06_fp16_amp1_E1_ms50_cal"
+        }
+      ],
+      "per_batch_alloc_bytes": 2444461824
+    }
+  ],
+  "guard_basis": "reserved",
+  "guard_ratio": 0.92,
+  "measure_steps": 50,
+  "notes": "OD1 only (out_dim=1). Do not reuse on different GPUs without refit. Probe harness unchanged.",
+  "overhead_bytes": 32029440,
+  "runs_root": "Golden Draft/bench_vault/_tmp/vra35_capacity_model_v1/20260205_224622",
+  "safe_start_ratio": 0.85,
+  "schema_version": "capacity_model_v1",
+  "track": {
+    "amp": 1,
+    "out_dim": 1,
+    "precision": "fp16"
+  }
+}

--- a/Golden Draft/tools/fit_gpu_capacity_model.py
+++ b/Golden Draft/tools/fit_gpu_capacity_model.py
@@ -1,0 +1,380 @@
+"""VRA-35: fit OD1 capacity model v1 from probe run folders.
+
+Reads probe artifacts under a gitignored runs-root and emits a committed,
+public-safe calibration JSON file (no secrets, no absolute paths).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+def _bootstrap_import_path() -> None:
+    """Ensure Golden Draft + Golden Code are importable for standalone runs."""
+
+    draftr = Path(__file__).resolve().parents[1]
+    reproo = draftr.parent
+
+    if str(draftr) not in sys.path:
+        sys.path.insert(0, str(draftr))
+
+    candls: list[str] = []
+    for keystr in ("VRAXION_GOLDEN_SRC", "GOLDEN_CODE_ROOT", "GOLDEN_CODE_PATH", "GOLDEN_CODE_DIR"):
+        envval = os.environ.get(keystr)
+        if envval:
+            candls.append(envval)
+
+    candls.append(str(reproo / "Golden Code"))
+    candls.append(r"S:\AI\Golden Code")
+    candls.append(r"S:/AI/Golden Code")
+
+    for candpt in candls:
+        try:
+            if candpt and os.path.isdir(candpt):
+                if candpt not in sys.path:
+                    sys.path.insert(0, candpt)
+                break
+        except OSError:
+            continue
+
+
+_bootstrap_import_path()
+
+
+from tools.gpu_capacity_model import GUARD_BASIS_RESERVED, SCHEMA_VERSION, compute_combo_key
+
+
+class FitError(RuntimeError):
+    pass
+
+
+def _stable_json_dump(path: Path, obj: Any) -> None:
+    path.write_text(json.dumps(obj, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+
+def _rel_repo_path(path: Path) -> str:
+    # Runs-root is already under the repo; keep output repo-relative and forward-slash.
+    try:
+        repo_root = Path(__file__).resolve().parents[2]
+        rel = path.resolve().relative_to(repo_root.resolve())
+        return rel.as_posix()
+    except Exception:
+        return path.as_posix()
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@dataclass(frozen=True)
+class RunRecord:
+    run_dir: Path
+    ant_path: Optional[str]
+    colony_path: Optional[str]
+    canonical_spec: dict[str, Any]
+    precision: str
+    amp: int
+    out_dim: int
+    measure_steps: int
+    batch: int
+    alloc: Optional[int]
+    reserved: Optional[int]
+    stability_pass: bool
+    had_oom: bool
+    had_nan: bool
+    had_inf: bool
+    fail_reasons: list[str]
+    total_vram_bytes: int
+    gpu_name: str
+    driver_version: Optional[str]
+    torch_version: Optional[str]
+    os_name: Optional[str]
+
+    @property
+    def is_pass(self) -> bool:
+        return bool(self.stability_pass and (not self.had_oom) and (not self.had_nan) and (not self.had_inf))
+
+    @property
+    def overhead_bytes(self) -> Optional[int]:
+        if self.alloc is None or self.reserved is None:
+            return None
+        return int(self.reserved) - int(self.alloc)
+
+
+def _parse_run_cmd_argv(argv: list[str]) -> tuple[Optional[str], Optional[str]]:
+    ant: Optional[str] = None
+    colony: Optional[str] = None
+    for idx, tok in enumerate(argv):
+        if tok == "--ant" and idx + 1 < len(argv):
+            ant = argv[idx + 1]
+        if tok == "--colony" and idx + 1 < len(argv):
+            colony = argv[idx + 1]
+    return ant, colony
+
+
+def try_load_run_record(run_dir: Path) -> Optional[RunRecord]:
+    run_cmd = run_dir / "run_cmd.txt"
+    metrics = run_dir / "metrics.json"
+    env = run_dir / "env.json"
+
+    if not (run_cmd.exists() and env.exists() and metrics.exists()):
+        return None
+
+    runcmd = _load_json(run_cmd)
+    argv = runcmd.get("argv") or []
+    ant_path, colony_path = _parse_run_cmd_argv(argv) if isinstance(argv, list) else (None, None)
+    canonical_spec = runcmd.get("canonical_spec")
+    if not isinstance(canonical_spec, dict):
+        return None
+
+    met = _load_json(metrics)
+    ev = _load_json(env)
+
+    try:
+        return RunRecord(
+            run_dir=run_dir,
+            ant_path=ant_path,
+            colony_path=colony_path,
+            canonical_spec=canonical_spec,
+            precision=str(met.get("precision")),
+            amp=int(met.get("amp")),
+            out_dim=int(met.get("out_dim")),
+            measure_steps=int(met.get("measure_steps")),
+            batch=int(met.get("batch_size")),
+            alloc=None if met.get("peak_vram_allocated_bytes") is None else int(met.get("peak_vram_allocated_bytes")),
+            reserved=None if met.get("peak_vram_reserved_bytes") is None else int(met.get("peak_vram_reserved_bytes")),
+            stability_pass=bool(met.get("stability_pass")),
+            had_oom=bool(met.get("had_oom")),
+            had_nan=bool(met.get("had_nan")),
+            had_inf=bool(met.get("had_inf")),
+            fail_reasons=list(met.get("fail_reasons") or []),
+            total_vram_bytes=int(ev.get("total_vram_bytes")),
+            gpu_name=str(ev.get("gpu_name")),
+            driver_version=ev.get("driver_version"),
+            torch_version=ev.get("torch_version"),
+            os_name=ev.get("os"),
+        )
+    except Exception:
+        return None
+
+
+def combo_spec_no_batch_from_canonical_spec(canonical_spec: dict[str, Any]) -> dict[str, Any]:
+    if canonical_spec.get("schema_version") != "workload_schema_v1":
+        raise FitError("unexpected schema_version in canonical_spec")
+    ant_spec = canonical_spec.get("ant_spec")
+    colony_spec = canonical_spec.get("colony_spec")
+    if not isinstance(ant_spec, dict) or not isinstance(colony_spec, dict):
+        raise FitError("canonical_spec missing ant_spec/colony_spec")
+    return {
+        "schema_version": "workload_schema_v1",
+        "ant_spec": ant_spec,
+        "colony_spec": {k: v for k, v in colony_spec.items() if k != "batch_size"},
+    }
+
+
+def _infer_combo_name(ant_path: Optional[str], colony_path: Optional[str]) -> str:
+    if ant_path and colony_path and ant_path.endswith(".json") and colony_path.endswith(".json"):
+        a = Path(ant_path).stem.replace("od1_", "").replace("_v1", "")
+        c = Path(colony_path).stem.replace("od1_", "").replace("_v1", "")
+        if a == "small" and c == "real":
+            return "C1_smallxreal"
+        if a == "real" and c == "real":
+            return "C2_realxreal"
+        if a == "stress" and c == "real":
+            return "C3_stressxreal"
+        if a == "real" and c == "small":
+            return "C4_realxsmall"
+        return f"{a}x{c}"
+    return "unknown_combo"
+
+
+def fit_capacity_model_v1(
+    *,
+    runs_root: Path,
+    guard_ratio: float,
+    safe_start_ratio: float,
+    guard_basis: str,
+    measure_steps: Optional[int],
+) -> dict[str, Any]:
+    if guard_basis != GUARD_BASIS_RESERVED:
+        raise FitError("v1 supports guard_basis=reserved only")
+
+    run_dirs = sorted([p for p in runs_root.iterdir() if p.is_dir()], key=lambda p: p.name)
+    recs = [r for p in run_dirs if (r := try_load_run_record(p)) is not None]
+    if not recs:
+        raise FitError("no complete runs found (expected run_cmd.txt + metrics.json + env.json)")
+
+    pass_recs = [r for r in recs if r.is_pass]
+    if not pass_recs:
+        raise FitError("no PASS runs found")
+
+    if measure_steps is None:
+        measure_steps = max(int(r.measure_steps) for r in pass_recs)
+
+    recs = [r for r in recs if int(r.measure_steps) == int(measure_steps)]
+    pass_recs = [r for r in recs if r.is_pass]
+    if not pass_recs:
+        raise FitError(f"no PASS runs found at measure_steps={measure_steps}")
+
+    prec = {r.precision for r in pass_recs}
+    amps = {int(r.amp) for r in pass_recs}
+    outs = {int(r.out_dim) for r in pass_recs}
+    if len(prec) != 1 or len(amps) != 1 or len(outs) != 1:
+        raise FitError("PASS runs have inconsistent (precision, amp, out_dim); filter your runs-root")
+
+    track = {"out_dim": int(next(iter(outs))), "precision": next(iter(prec)), "amp": int(next(iter(amps)))}
+    if int(track["out_dim"]) != 1:
+        raise FitError("capacity model v1 is OD1 only (out_dim=1)")
+
+    overheads = [r.overhead_bytes for r in pass_recs if r.overhead_bytes is not None]
+    if not overheads:
+        raise FitError("cannot compute overhead median (missing alloc/reserved in PASS runs)")
+    overhead_bytes = int(round(float(statistics.median(overheads))))
+
+    tv = {int(r.total_vram_bytes) for r in pass_recs}
+    if len(tv) != 1:
+        raise FitError("PASS runs disagree on total_vram_bytes; refusing to fit")
+    exemplar = sorted(pass_recs, key=lambda r: (r.gpu_name, r.batch, r.run_dir.name))[0]
+    calibrated_on = {
+        "gpu_name": exemplar.gpu_name,
+        "total_vram_bytes": int(exemplar.total_vram_bytes),
+        "driver_version": exemplar.driver_version,
+        "torch_version": exemplar.torch_version,
+        "os": exemplar.os_name,
+    }
+
+    by_combo: dict[str, list[RunRecord]] = {}
+    combo_meta: dict[str, dict[str, Any]] = {}
+    for r in recs:
+        spec_nb = combo_spec_no_batch_from_canonical_spec(r.canonical_spec)
+        ck = compute_combo_key(spec_nb)
+        by_combo.setdefault(ck, []).append(r)
+        if ck not in combo_meta:
+            combo_meta[ck] = {
+                "combo_spec_no_batch": spec_nb,
+                "combo_name": _infer_combo_name(r.ant_path, r.colony_path),
+                "ant_path": r.ant_path,
+                "colony_path": r.colony_path,
+            }
+
+    combos_out: list[dict[str, Any]] = []
+    for ck in sorted(by_combo.keys(), key=lambda k: combo_meta[k]["combo_name"]):
+        runs = by_combo[ck]
+        pass_runs = sorted([r for r in runs if r.is_pass], key=lambda r: (r.batch, r.run_dir.name))
+        if not pass_runs:
+            continue
+
+        measured_max = max(int(r.batch) for r in pass_runs)
+        fail_above = sorted(
+            [r for r in runs if (not r.is_pass) and int(r.batch) > int(measured_max)],
+            key=lambda r: (r.batch, r.run_dir.name),
+        )
+        boundary_fail = fail_above[0] if fail_above else None
+
+        fit_points: list[RunRecord] = []
+        if pass_runs:
+            fit_points.append(pass_runs[0])
+            for r in pass_runs[1:]:
+                if int(r.batch) != int(fit_points[0].batch):
+                    fit_points.append(r)
+                    break
+
+        base_alloc: Optional[int] = None
+        per_batch: Optional[int] = None
+        if len(fit_points) >= 2 and fit_points[0].alloc is not None and fit_points[1].alloc is not None:
+            r1, r2 = fit_points[0], fit_points[1]
+            db = int(r2.batch) - int(r1.batch)
+            if db <= 0:
+                raise FitError("invalid fit batch ordering")
+            per = (int(r2.alloc) - int(r1.alloc)) / float(db)
+            per_batch = int(round(per))
+            base_alloc = int(round(int(r1.alloc) - per_batch * int(r1.batch)))
+
+        combos_out.append(
+            {
+                "combo_name": combo_meta[ck]["combo_name"],
+                "combo_key": ck,
+                "ant_path": combo_meta[ck]["ant_path"],
+                "colony_path": combo_meta[ck]["colony_path"],
+                "combo_spec_no_batch": combo_meta[ck]["combo_spec_no_batch"],
+                "base_alloc_bytes": base_alloc,
+                "per_batch_alloc_bytes": per_batch,
+                "measured_max_batch": int(measured_max),
+                "boundary_fail_batch": None if boundary_fail is None else int(boundary_fail.batch),
+                "boundary_fail_reasons": None if boundary_fail is None else list(boundary_fail.fail_reasons),
+                "fit_points": [
+                    {
+                        "batch": int(r.batch),
+                        "alloc": r.alloc,
+                        "reserved": r.reserved,
+                        "run_dir": _rel_repo_path(r.run_dir),
+                    }
+                    for r in fit_points
+                    if r.alloc is not None and r.reserved is not None
+                ],
+                "pass_runs": [
+                    {
+                        "batch": int(r.batch),
+                        "alloc": r.alloc,
+                        "reserved": r.reserved,
+                        "run_dir": _rel_repo_path(r.run_dir),
+                    }
+                    for r in pass_runs
+                    if r.alloc is not None and r.reserved is not None
+                ],
+            }
+        )
+
+    if not combos_out:
+        raise FitError("no combos emitted (did all runs fail parsing?)")
+
+    combos_out = sorted(combos_out, key=lambda c: str(c["combo_name"]))
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "guard_basis": guard_basis,
+        "guard_ratio": float(guard_ratio),
+        "safe_start_ratio": float(safe_start_ratio),
+        "track": track,
+        "calibrated_on": calibrated_on,
+        "overhead_bytes": int(overhead_bytes),
+        "measure_steps": int(measure_steps),
+        "runs_root": _rel_repo_path(runs_root),
+        "combos": combos_out,
+        "notes": "OD1 only (out_dim=1). Do not reuse on different GPUs without refit. Probe harness unchanged.",
+    }
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description="Fit VRA-35 capacity_model_v1.json from probe run folders.")
+    ap.add_argument("--runs-root", required=True, help="Root folder containing probe run directories.")
+    ap.add_argument("--out", required=True, help="Output JSON path (e.g. Golden Draft/tools/capacity_model_v1.json).")
+    ap.add_argument("--guard-basis", default=GUARD_BASIS_RESERVED, help="Guard basis (v1 supports reserved only).")
+    ap.add_argument("--guard-ratio", type=float, default=0.92, help="VRAM guard ratio (reserved).")
+    ap.add_argument("--safe-start-ratio", type=float, default=0.85, help="Conservative SAFE_START ratio.")
+    ap.add_argument("--measure-steps", type=int, default=None, help="Filter to this measure_steps (default: max PASS).")
+
+    ns = ap.parse_args(argv)
+    try:
+        model = fit_capacity_model_v1(
+            runs_root=Path(ns.runs_root),
+            guard_ratio=float(ns.guard_ratio),
+            safe_start_ratio=float(ns.safe_start_ratio),
+            guard_basis=str(ns.guard_basis),
+            measure_steps=ns.measure_steps,
+        )
+        _stable_json_dump(Path(ns.out), model)
+        return 0
+    except FitError as exc:
+        print(f"fit error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Golden Draft/tools/gpu_capacity_model.py
+++ b/Golden Draft/tools/gpu_capacity_model.py
@@ -1,0 +1,269 @@
+"""VRA-35: OD1 capacity model (SAFE_START + MAX batch) from calibration JSON.
+
+Guardrails (v1):
+- Does NOT modify the probe harness.
+- Does NOT hardcode calibration constants in code.
+- OD1 only: out_dim must be 1.
+- Guard basis: reserved bytes (peak_vram_reserved_bytes) only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+
+SCHEMA_VERSION = "capacity_model_v1"
+GUARD_BASIS_RESERVED = "reserved"
+
+
+class CapacityModelError(RuntimeError):
+    pass
+
+
+def _stable_json(obj: Any) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _sha12_hex(data: str) -> str:
+    return hashlib.sha256(data.encode("utf-8")).hexdigest()[:12]
+
+
+def compute_combo_key(combo_spec_no_batch: Mapping[str, Any]) -> str:
+    """Compute a stable key for a (ant_spec, colony_spec-without-batch) spec."""
+
+    return f"combo_v1_{_sha12_hex(_stable_json(combo_spec_no_batch))}"
+
+
+def _req(obj: Mapping[str, Any], key: str) -> Any:
+    if key not in obj:
+        raise CapacityModelError(f"missing required key: {key}")
+    return obj[key]
+
+
+def _as_int(name: str, val: Any) -> int:
+    if isinstance(val, bool) or not isinstance(val, (int, float)) or math.isnan(float(val)):
+        raise CapacityModelError(f"{name} must be a number, got {type(val).__name__}")
+    return int(val)
+
+
+def _as_float(name: str, val: Any) -> float:
+    if isinstance(val, bool) or not isinstance(val, (int, float)) or math.isnan(float(val)):
+        raise CapacityModelError(f"{name} must be a number, got {type(val).__name__}")
+    return float(val)
+
+
+@dataclass(frozen=True)
+class CapacityTrack:
+    out_dim: int
+    precision: str
+    amp: int
+
+
+@dataclass(frozen=True)
+class CapacityCombo:
+    combo_name: str
+    combo_key: str
+    combo_spec_no_batch: Mapping[str, Any]
+    base_alloc_bytes: Optional[int]
+    per_batch_alloc_bytes: Optional[int]
+    measured_max_batch: Optional[int]
+
+
+@dataclass(frozen=True)
+class CapacityModelV1:
+    guard_basis: str
+    guard_ratio: float
+    safe_start_ratio: float
+    track: CapacityTrack
+    calibrated_on: Mapping[str, Any]
+    overhead_bytes: int
+    combos_by_key: Mapping[str, CapacityCombo]
+
+    def assert_track_compatible(self, *, out_dim: int) -> None:
+        if int(out_dim) != int(self.track.out_dim):
+            raise CapacityModelError(f"out_dim={out_dim} unsupported by model (expects {self.track.out_dim})")
+        if int(out_dim) != 1:
+            raise CapacityModelError("capacity model v1 supports out_dim=1 only")
+
+    def _estimate_from_combo(
+        self,
+        combo: CapacityCombo,
+        *,
+        guard_ratio: float,
+        total_vram_bytes: int,
+        capacity_bytes: int,
+    ) -> int:
+        if combo.per_batch_alloc_bytes is None or combo.base_alloc_bytes is None:
+            if combo.measured_max_batch is not None:
+                return int(combo.measured_max_batch)
+            raise CapacityModelError(
+                f"combo {combo.combo_name} has no slope/intercept and no measured_max_batch; cannot estimate"
+            )
+
+        per_batch = int(combo.per_batch_alloc_bytes)
+        base = int(combo.base_alloc_bytes)
+        if per_batch <= 0:
+            raise CapacityModelError(f"combo {combo.combo_name} has invalid per_batch_alloc_bytes={per_batch}")
+
+        numer = capacity_bytes - int(self.overhead_bytes) - base
+        if numer <= 0:
+            return 1
+
+        bmax = int(math.floor(numer / per_batch))
+        bmax = max(1, bmax)
+
+        if total_vram_bytes > 0 and bmax > 1_000_000:
+            raise CapacityModelError(f"unreasonable MAX batch computed: {bmax}")
+        return bmax
+
+    def estimate_max_batch(
+        self,
+        combo_key: str,
+        *,
+        guard_ratio: float,
+        total_vram_bytes: Optional[int] = None,
+    ) -> int:
+        if self.guard_basis != GUARD_BASIS_RESERVED:
+            raise CapacityModelError(f"unsupported guard_basis={self.guard_basis} (v1 expects reserved)")
+
+        combo = self.combos_by_key.get(combo_key)
+        if combo is None:
+            raise CapacityModelError(f"no calibration found for combo_key={combo_key}")
+
+        tvb = int(total_vram_bytes) if total_vram_bytes is not None else _as_int(
+            "calibrated_on.total_vram_bytes", _req(self.calibrated_on, "total_vram_bytes")
+        )
+        cap = int(math.floor(float(guard_ratio) * tvb))
+        return self._estimate_from_combo(combo, guard_ratio=float(guard_ratio), total_vram_bytes=tvb, capacity_bytes=cap)
+
+    def estimate_safe_start_batch(
+        self,
+        combo_key: str,
+        *,
+        total_vram_bytes: Optional[int] = None,
+    ) -> int:
+        tvb = int(total_vram_bytes) if total_vram_bytes is not None else _as_int(
+            "calibrated_on.total_vram_bytes", _req(self.calibrated_on, "total_vram_bytes")
+        )
+        cap = int(math.floor(float(self.safe_start_ratio) * tvb))
+        max_b = self.estimate_max_batch(combo_key, guard_ratio=self.guard_ratio, total_vram_bytes=tvb)
+        safe_b = self._estimate_from_combo(
+            _req(self.combos_by_key, combo_key),
+            guard_ratio=self.safe_start_ratio,
+            total_vram_bytes=tvb,
+            capacity_bytes=cap,
+        )
+        return max(1, min(int(safe_b), int(max_b)))
+
+
+def load_capacity_model(path: str | Path) -> CapacityModelV1:
+    pth = Path(path)
+    data = json.loads(pth.read_text(encoding="utf-8"))
+    if _req(data, "schema_version") != SCHEMA_VERSION:
+        raise CapacityModelError("unsupported schema_version")
+
+    guard_basis = str(_req(data, "guard_basis"))
+    guard_ratio = _as_float("guard_ratio", _req(data, "guard_ratio"))
+    safe_ratio = _as_float("safe_start_ratio", _req(data, "safe_start_ratio"))
+
+    track_obj = _req(data, "track")
+    track = CapacityTrack(
+        out_dim=_as_int("track.out_dim", _req(track_obj, "out_dim")),
+        precision=str(_req(track_obj, "precision")),
+        amp=_as_int("track.amp", _req(track_obj, "amp")),
+    )
+
+    overhead = _as_int("overhead_bytes", _req(data, "overhead_bytes"))
+    calibrated_on = _req(data, "calibrated_on")
+    if not isinstance(calibrated_on, dict):
+        raise CapacityModelError("calibrated_on must be an object")
+
+    combos_obj = _req(data, "combos")
+    if not isinstance(combos_obj, list):
+        raise CapacityModelError("combos must be a list")
+
+    combos: dict[str, CapacityCombo] = {}
+    for idx, c in enumerate(combos_obj):
+        if not isinstance(c, dict):
+            raise CapacityModelError(f"combos[{idx}] must be an object")
+        key = str(_req(c, "combo_key"))
+        if key in combos:
+            raise CapacityModelError(f"duplicate combo_key in model: {key}")
+        base = c.get("base_alloc_bytes")
+        perb = c.get("per_batch_alloc_bytes")
+        measured_max = c.get("measured_max_batch")
+        combos[key] = CapacityCombo(
+            combo_name=str(_req(c, "combo_name")),
+            combo_key=key,
+            combo_spec_no_batch=_req(c, "combo_spec_no_batch"),
+            base_alloc_bytes=None if base is None else _as_int("base_alloc_bytes", base),
+            per_batch_alloc_bytes=None if perb is None else _as_int("per_batch_alloc_bytes", perb),
+            measured_max_batch=None if measured_max is None else _as_int("measured_max_batch", measured_max),
+        )
+
+    return CapacityModelV1(
+        guard_basis=guard_basis,
+        guard_ratio=float(guard_ratio),
+        safe_start_ratio=float(safe_ratio),
+        track=track,
+        calibrated_on=calibrated_on,
+        overhead_bytes=int(overhead),
+        combos_by_key=combos,
+    )
+
+
+def compute_combo_key_from_workload_files(
+    ant_path: str | Path,
+    colony_path: str | Path,
+    *,
+    precision_override: Optional[str] = None,
+) -> tuple[dict[str, Any], str]:
+    """Compute the capacity combo key for (ant_spec from ant_path, colony_spec from colony_path)."""
+
+    from tools import workload_id
+
+    ant = workload_id.load_workload_spec(str(ant_path))
+    col = workload_id.load_workload_spec(str(colony_path))
+    ant_canon = workload_id.canonicalize_spec(ant)
+    col_canon = workload_id.canonicalize_spec(col)
+
+    schema_version = str(_req(ant_canon, "schema_version"))
+    if str(_req(col_canon, "schema_version")) != schema_version:
+        raise CapacityModelError("schema_version mismatch between ant and colony specs")
+
+    combo_spec_no_batch: dict[str, Any] = {
+        "schema_version": schema_version,
+        "ant_spec": _req(ant_canon, "ant_spec"),
+        "colony_spec": {k: v for k, v in _req(col_canon, "colony_spec").items() if k != "batch_size"},
+    }
+    if precision_override is not None:
+        combo_spec_no_batch["ant_spec"] = dict(combo_spec_no_batch["ant_spec"])
+        combo_spec_no_batch["ant_spec"]["precision"] = str(precision_override)
+    return combo_spec_no_batch, compute_combo_key(combo_spec_no_batch)
+
+
+def estimate_safe_start_and_max(
+    *,
+    ant_path: str | Path,
+    colony_path: str | Path,
+    model_path: str | Path,
+    guard_ratio: Optional[float] = None,
+    total_vram_bytes: Optional[int] = None,
+) -> tuple[int, int]:
+    model = load_capacity_model(model_path)
+    model.assert_track_compatible(out_dim=model.track.out_dim)
+
+    _, combo_key = compute_combo_key_from_workload_files(
+        ant_path,
+        colony_path,
+        precision_override=model.track.precision,
+    )
+    gr = float(model.guard_ratio if guard_ratio is None else guard_ratio)
+    max_b = model.estimate_max_batch(combo_key, guard_ratio=gr, total_vram_bytes=total_vram_bytes)
+    safe_b = model.estimate_safe_start_batch(combo_key, total_vram_bytes=total_vram_bytes)
+    return safe_b, max_b

--- a/Golden Draft/tools/gpu_capacity_pick_batch.py
+++ b/Golden Draft/tools/gpu_capacity_pick_batch.py
@@ -1,0 +1,84 @@
+"""VRA-35 helper: print SAFE_START and MAX batch for a workload combo.
+
+This does not modify the probe harness; it is intended for later sweep tooling.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+def _bootstrap_import_path() -> None:
+    """Ensure Golden Draft + Golden Code are importable for standalone runs."""
+
+    draftr = Path(__file__).resolve().parents[1]
+    reproo = draftr.parent
+
+    if str(draftr) not in sys.path:
+        sys.path.insert(0, str(draftr))
+
+    candls: list[str] = []
+    for keystr in ("VRAXION_GOLDEN_SRC", "GOLDEN_CODE_ROOT", "GOLDEN_CODE_PATH", "GOLDEN_CODE_DIR"):
+        envval = os.environ.get(keystr)
+        if envval:
+            candls.append(envval)
+
+    candls.append(str(reproo / "Golden Code"))
+    candls.append(r"S:\AI\Golden Code")
+    candls.append(r"S:/AI/Golden Code")
+
+    for candpt in candls:
+        try:
+            if candpt and os.path.isdir(candpt):
+                if candpt not in sys.path:
+                    sys.path.insert(0, candpt)
+                break
+        except OSError:
+            continue
+
+
+_bootstrap_import_path()
+
+
+from tools import gpu_capacity_model
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description="Pick SAFE_START and MAX batch from VRA-35 capacity model.")
+    ap.add_argument("--ant", required=True, help="Path to workload spec JSON (ant_spec source).")
+    ap.add_argument("--colony", required=True, help="Path to workload spec JSON (colony_spec source).")
+    ap.add_argument(
+        "--model",
+        default=str(Path("Golden Draft") / "tools" / "capacity_model_v1.json"),
+        help="Capacity model JSON path.",
+    )
+    ap.add_argument("--guard-ratio", type=float, default=None, help="Override guard ratio (default: model.guard_ratio).")
+    ap.add_argument(
+        "--total-vram-bytes",
+        type=int,
+        default=None,
+        help="Override total VRAM bytes (default: model.calibrated_on.total_vram_bytes).",
+    )
+
+    ns = ap.parse_args(argv)
+    try:
+        safe_b, max_b = gpu_capacity_model.estimate_safe_start_and_max(
+            ant_path=ns.ant,
+            colony_path=ns.colony,
+            model_path=ns.model,
+            guard_ratio=ns.guard_ratio,
+            total_vram_bytes=ns.total_vram_bytes,
+        )
+        print(f"SAFE_START={safe_b}")
+        print(f"MAX={max_b}")
+        return 0
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/VERSION.json
+++ b/VERSION.json
@@ -1,5 +1,5 @@
 {
   "major": 2,
   "minor": 10,
-  "build": 577
+  "build": 578
 }


### PR DESCRIPTION
Implements VRA-35 (OD1 capacity model v1): calibration JSON + estimators to predict SAFE_START and MAX batch for canonical OD1 workload combos.\n\nProbe harness unchanged (no edits to Golden Draft/tools/gpu_capacity_probe.py).\n\nTrack/guard:\n- out_dim=1\n- precision=fp16, amp=1\n- measure_steps=50\n- guard basis: peak_vram_reserved_bytes (reserved)\n- guard ratio: 0.92\n- SAFE_START ratio: 0.85\n\nCalibration file (committed): Golden Draft/tools/capacity_model_v1.json\n\nEvidence table + variance check: see the first PR comment.

---

Roadmap linkage:
Closes #46

