### PR TITLE
VRA-35 pass-2: strict portability + adversarial safeguards

### DIFF
--- a/Golden Draft/tests/test_gpu_capacity_pick_batch.py
+++ b/Golden Draft/tests/test_gpu_capacity_pick_batch.py
@@ -1,0 +1,109 @@
+"""VRA-35 pass-2 tests: strict runtime portability for gpu_capacity_pick_batch CLI."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import conftest  # noqa: F401  (import side-effect: sys.path bootstrap)
+
+from tools import gpu_capacity_model
+
+
+class TestGpuCapacityPickBatchCli(unittest.TestCase):
+    def test_strict_requires_runtime_vram_and_override_warns(self) -> None:
+        ant_spec = {
+            "schema_version": "workload_schema_v1",
+            "ant_spec": {"ring_len": 32, "slot_dim": 16, "ptr_dtype": "fp64", "precision": "fp32"},
+            "colony_spec": {
+                "seq_len": 8,
+                "synth_len": 8,
+                "batch_size": 4,
+                "ptr_update_every": 1,
+                "state_loop_samples": 0,
+            },
+        }
+        colony_spec = {
+            "schema_version": "workload_schema_v1",
+            "ant_spec": {"ring_len": 64, "slot_dim": 32, "ptr_dtype": "fp64", "precision": "fp32"},
+            "colony_spec": {
+                "seq_len": 8,
+                "synth_len": 8,
+                "batch_size": 16,
+                "ptr_update_every": 1,
+                "state_loop_samples": 0,
+            },
+        }
+
+        script = Path(__file__).resolve().parents[1] / "tools" / "gpu_capacity_pick_batch.py"
+        repo_root = Path(__file__).resolve().parents[2]
+
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            ant_path = tmp / "ant.json"
+            colony_path = tmp / "colony.json"
+            ant_path.write_text(json.dumps(ant_spec, indent=2) + "\n", encoding="utf-8")
+            colony_path.write_text(json.dumps(colony_spec, indent=2) + "\n", encoding="utf-8")
+
+            _, combo_key = gpu_capacity_model.compute_combo_key_from_workload_files(
+                ant_path, colony_path, precision_override="fp16"
+            )
+            model = {
+                "schema_version": "capacity_model_v1",
+                "guard_basis": "reserved",
+                "guard_ratio": 0.92,
+                "safe_start_ratio": 0.85,
+                "track": {"out_dim": 1, "precision": "fp16", "amp": 1},
+                "calibrated_on": {"gpu_name": "GPU_A", "total_vram_bytes": 1000},
+                "overhead_bytes": 5,
+                "combos": [
+                    {
+                        "combo_name": "CX",
+                        "combo_key": combo_key,
+                        "combo_spec_no_batch": {},
+                        "base_alloc_bytes": 100,
+                        "per_batch_alloc_bytes": 10,
+                        "measured_max_batch": None,
+                    }
+                ],
+            }
+            model_path = tmp / "model.json"
+            model_path.write_text(json.dumps(model, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+            def _run(extra: list[str]) -> subprocess.CompletedProcess[str]:
+                cmd = [
+                    sys.executable,
+                    str(script),
+                    "--ant",
+                    str(ant_path),
+                    "--colony",
+                    str(colony_path),
+                    "--model",
+                    str(model_path),
+                    *extra,
+                ]
+                return subprocess.run(cmd, cwd=str(repo_root), capture_output=True, text=True, timeout=20)
+
+            missing_runtime = _run([])
+            self.assertEqual(missing_runtime.returncode, 2)
+            self.assertIn("runtime VRAM is required", missing_runtime.stderr)
+
+            strict_mismatch = _run(["--total-vram-bytes", "900"])
+            self.assertEqual(strict_mismatch.returncode, 2)
+            self.assertIn("calibration/runtime mismatch", strict_mismatch.stderr)
+
+            allowed_mismatch = _run(["--total-vram-bytes", "900", "--allow-gpu-mismatch"])
+            self.assertEqual(allowed_mismatch.returncode, 0)
+            self.assertIn("SAFE_START=", allowed_mismatch.stdout)
+            self.assertIn("MAX=", allowed_mismatch.stdout)
+            self.assertIn("WARNING: calibration/runtime mismatch", allowed_mismatch.stderr)
+
+            strict_match = _run(["--total-vram-bytes", "1000"])
+            self.assertEqual(strict_match.returncode, 0)
+            self.assertIn("SAFE_START=", strict_match.stdout)
+            self.assertIn("MAX=", strict_match.stdout)
+

--- a/Golden Draft/tools/gpu_capacity_pick_batch.py
+++ b/Golden Draft/tools/gpu_capacity_pick_batch.py
@@ -60,18 +60,58 @@ def main(argv: Optional[list[str]] = None) -> int:
         "--total-vram-bytes",
         type=int,
         default=None,
-        help="Override total VRAM bytes (default: model.calibrated_on.total_vram_bytes).",
+        help="Runtime total VRAM bytes (required unless --env-json provides it).",
+    )
+    ap.add_argument(
+        "--env-json",
+        default=None,
+        help="Runtime env json path containing total_vram_bytes (and optionally gpu_name).",
+    )
+    ap.add_argument(
+        "--allow-gpu-mismatch",
+        action="store_true",
+        help="Proceed on runtime/calibration mismatch with an explicit warning.",
     )
 
     ns = ap.parse_args(argv)
     try:
-        safe_b, max_b = gpu_capacity_model.estimate_safe_start_and_max(
-            ant_path=ns.ant,
-            colony_path=ns.colony,
-            model_path=ns.model,
-            guard_ratio=ns.guard_ratio,
-            total_vram_bytes=ns.total_vram_bytes,
+        model = gpu_capacity_model.load_capacity_model(ns.model)
+        runtime_gpu_name: Optional[str] = None
+        runtime_total_vram: Optional[int] = None if ns.total_vram_bytes is None else int(ns.total_vram_bytes)
+        if ns.env_json:
+            runtime_ctx = gpu_capacity_model.load_runtime_context_from_env_json(ns.env_json)
+            runtime_gpu_name = runtime_ctx.gpu_name
+            if runtime_total_vram is None:
+                runtime_total_vram = int(runtime_ctx.total_vram_bytes)
+        if runtime_total_vram is None:
+            raise gpu_capacity_model.CapacityModelError(
+                "runtime VRAM is required: pass --total-vram-bytes or --env-json"
+            )
+
+        issues = gpu_capacity_model.runtime_compatibility_issues(
+            model,
+            runtime_total_vram_bytes=runtime_total_vram,
+            runtime_gpu_name=runtime_gpu_name,
         )
+        if issues and not ns.allow_gpu_mismatch:
+            raise gpu_capacity_model.CapacityModelError(
+                "calibration/runtime mismatch: "
+                + "; ".join(issues)
+                + ". Re-run with --allow-gpu-mismatch only if this is intentional."
+            )
+        if issues and ns.allow_gpu_mismatch:
+            print("WARNING: calibration/runtime mismatch accepted via --allow-gpu-mismatch:", file=sys.stderr)
+            for issue in issues:
+                print(f"WARNING: {issue}", file=sys.stderr)
+
+        _, combo_key = gpu_capacity_model.compute_combo_key_from_workload_files(
+            ns.ant,
+            ns.colony,
+            precision_override=model.track.precision,
+        )
+        guard_ratio = float(model.guard_ratio if ns.guard_ratio is None else ns.guard_ratio)
+        max_b = model.estimate_max_batch(combo_key, guard_ratio=guard_ratio, total_vram_bytes=runtime_total_vram)
+        safe_b = model.estimate_safe_start_batch(combo_key, total_vram_bytes=runtime_total_vram)
         print(f"SAFE_START={safe_b}")
         print(f"MAX={max_b}")
         return 0


### PR DESCRIPTION
## Scope
VRA-35 pass-2 hardening for strict portability and adversarial safeguards.

## Changes
- Enforce strict runtime VRAM requirement in `gpu_capacity_pick_batch.py`.
- Add `--env-json` runtime metadata input and `--allow-gpu-mismatch` explicit override with warning.
- Add runtime compatibility checks in `gpu_capacity_model.py` (VRAM/GPU mismatch detection).
- Extend model tests and add CLI adversarial test coverage.
- Probe harness remains unchanged.

## Validation
- `python -m unittest discover -s "Golden Draft/tests" -v` (136 tests, pass)
- `python -m compileall "Golden Code" "Golden Draft"` (pass)

## Smoke checks
- Strict missing runtime VRAM -> fails with explicit message.
- Strict with exact calibrated VRAM -> succeeds.
- Mismatch without override -> fails.
- Mismatch with `--allow-gpu-mismatch` -> warns and proceeds.

## Notes
- No sweep/training changes.
- No `gpu_capacity_probe.py` edits.



---

Roadmap linkage:
Closes #47

