### PR TITLE
VRA-78: watchdog-first sweep hardening + eval heartbeat

### DIFF
--- a/Golden Draft/tests/test_ant_ratio_eval_timeout_zero.py
+++ b/Golden Draft/tests/test_ant_ratio_eval_timeout_zero.py
@@ -1,0 +1,51 @@
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import conftest  # noqa: F401  (import side-effect: sys.path bootstrap)
+
+
+class TestAntRatioEvalTimeoutZero(unittest.TestCase):
+    def test_timeout_zero_disables_subprocess_timeout(self) -> None:
+        from tools.ant_ratio_sweep_v0 import _run_capability_eval
+
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            tool = repo_root / "Golden Draft" / "tools" / "eval_ckpt_assoc_byte.py"
+            tool.parent.mkdir(parents=True, exist_ok=True)
+            tool.write_text("# stub", encoding="utf-8")
+
+            run_root = repo_root / "runs" / "assoc"
+            run_root.mkdir(parents=True, exist_ok=True)
+            report = run_root / "report.json"
+            report.write_text("{}", encoding="utf-8")
+            (run_root / "vraxion_eval.log").write_text("", encoding="utf-8")
+            checkpoint = run_root / "checkpoint_last_good.pt"
+            checkpoint.write_bytes(b"fake")
+
+            with mock.patch(
+                "tools.ant_ratio_sweep_v0.subprocess.run", return_value=SimpleNamespace(returncode=0)
+            ) as mrun:
+                got_report, hb_seen = _run_capability_eval(
+                    repo_root=repo_root,
+                    run_root=run_root,
+                    checkpoint=checkpoint,
+                    eval_samples=512,
+                    batch_size=2,
+                    device="cpu",
+                    eval_seed_offset=1000003,
+                    force_disjoint=True,
+                    timeout_s=0,
+                    heartbeat_s=60,
+                )
+
+            self.assertEqual(got_report, report)
+            self.assertFalse(hb_seen)
+            _, kwargs = mrun.call_args
+            self.assertIsNone(kwargs.get("timeout"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Golden Draft/tests/test_ant_ratio_incremental_flush.py
+++ b/Golden Draft/tests/test_ant_ratio_incremental_flush.py
@@ -1,0 +1,121 @@
+import csv
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import conftest  # noqa: F401  (import side-effect: sys.path bootstrap)
+
+
+class TestAntRatioIncrementalFlush(unittest.TestCase):
+    def test_flush_writes_after_each_config(self) -> None:
+        from tools import ant_ratio_sweep_v0 as sweep
+        from tools import ant_ratio_packet_v0 as pktmod
+        from tools import ant_ratio_plot_v0 as pltmod
+
+        with tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+            out_root = td_path / "out"
+            batch_targets = td_path / "batch_targets.json"
+            batch_targets.write_text(
+                json.dumps(
+                    {
+                        "rows": [
+                            {"ant_tier": "small", "expert_heads": 1, "chosen_batch": 2, "unusable": False},
+                            {"ant_tier": "real", "expert_heads": 4, "chosen_batch": 3, "unusable": False},
+                        ]
+                    },
+                    sort_keys=True,
+                ),
+                encoding="utf-8",
+            )
+
+            def _fake_probe(**kwargs):
+                out_dir = Path(kwargs["out_dir"])
+                if "real_E4" in str(out_dir):
+                    raise sweep.SweepError("forced probe failure")
+                out_dir.mkdir(parents=True, exist_ok=True)
+                return out_dir, {"stability_pass": True, "had_oom": False, "had_nan": False, "had_inf": False}
+
+            def _fake_train(**kwargs):
+                run_root = Path(kwargs["run_root"])
+                run_root.mkdir(parents=True, exist_ok=True)
+                ckpt = run_root / "checkpoint_last_good.pt"
+                ckpt.write_bytes(b"fake")
+                return ckpt, 0
+
+            def _fake_eval(**kwargs):
+                run_root = Path(kwargs["run_root"])
+                rep = run_root / "report.json"
+                rep.write_text("{}", encoding="utf-8")
+                return rep, True
+
+            def _fake_packet(**kwargs):
+                return {
+                    "schema_version": "ant_ratio_packet_v0",
+                    "git_commit": "fake",
+                    "generated_utc": "2026-02-07T00:00:00Z",
+                    "ant_tier": kwargs.get("ant_tier_override", "small"),
+                    "expert_heads": 1,
+                    "batch_size": 2,
+                    "precision": "fp16",
+                    "amp": 1,
+                    "vram_ratio_reserved": 0.84,
+                    "throughput_tokens_per_s": 100.0,
+                    "assoc_byte_disjoint_accuracy": 0.12,
+                    "assoc_eval_n": 512,
+                    "token_budget_steps": int(kwargs.get("capability_steps_override", 30)),
+                    "probe_run_root": str(kwargs.get("probe_run_root")),
+                    "assoc_run_root": str(kwargs.get("assoc_run_root")),
+                    "stability_pass": True,
+                    "fail_reasons": [],
+                }
+
+            real_write_csv = sweep._write_csv
+            with (
+                mock.patch.dict(sys.modules, {"ant_ratio_packet_v0": pktmod, "ant_ratio_plot_v0": pltmod}),
+                mock.patch("tools.ant_ratio_sweep_v0._repo_root", return_value=td_path),
+                mock.patch("tools.ant_ratio_sweep_v0._run_probe", side_effect=_fake_probe),
+                mock.patch("tools.ant_ratio_sweep_v0._run_capability_train", side_effect=_fake_train),
+                mock.patch("tools.ant_ratio_sweep_v0._run_capability_eval", side_effect=_fake_eval),
+                mock.patch.object(pktmod, "build_packet", side_effect=_fake_packet),
+                mock.patch.object(pltmod, "build_html", return_value="<html></html>"),
+                mock.patch("tools.ant_ratio_sweep_v0._write_csv", wraps=real_write_csv) as mwrite_csv,
+            ):
+                rc = sweep.main(
+                    [
+                        "--batch-targets",
+                        str(batch_targets),
+                        "--out-root",
+                        str(out_root),
+                        "--flush-every-config",
+                        "1",
+                    ]
+                )
+
+            self.assertEqual(rc, 0)
+            self.assertGreaterEqual(mwrite_csv.call_count, 3)
+
+            summary = out_root / "ant_ratio_summary.csv"
+            packets = out_root / "ant_ratio_packets.jsonl"
+            failures = out_root / "sweep_failures.json"
+            self.assertTrue(summary.exists())
+            self.assertTrue(packets.exists())
+            self.assertTrue(failures.exists())
+
+            with summary.open("r", encoding="utf-8", newline="") as f:
+                rows = list(csv.DictReader(f))
+            self.assertEqual(len(rows), 2)
+            self.assertEqual(sum(1 for r in rows if r.get("status") == "ok"), 1)
+            self.assertEqual(sum(1 for r in rows if r.get("status") == "error"), 1)
+
+            packet_lines = [ln for ln in packets.read_text(encoding="utf-8").splitlines() if ln.strip()]
+            self.assertEqual(len(packet_lines), 1)
+            fail_obj = json.loads(failures.read_text(encoding="utf-8"))
+            self.assertEqual(len(fail_obj.get("failures", [])), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Golden Draft/tests/test_ant_ratio_sweep_eval_device.py
+++ b/Golden Draft/tests/test_ant_ratio_sweep_eval_device.py
@@ -24,6 +24,10 @@ class TestAntRatioSweepEvalDevice(unittest.TestCase):
             run_root.mkdir(parents=True, exist_ok=True)
             rep = run_root / "report.json"
             rep.write_text('{"eval_acc": 0.0, "eval_n": 512}', encoding="utf-8")
+            (run_root / "vraxion_eval.log").write_text(
+                "[eval_ckpt][heartbeat] stage=eval elapsed_s=1 interval_s=60 pulse=1\n",
+                encoding="utf-8",
+            )
 
             ckpt = run_root / "checkpoint_last_good.pt"
             ckpt.write_bytes(b"fake")
@@ -31,7 +35,7 @@ class TestAntRatioSweepEvalDevice(unittest.TestCase):
             with mock.patch(
                 "tools.ant_ratio_sweep_v0.subprocess.run", return_value=SimpleNamespace(returncode=123)
             ) as mrun:
-                got = _run_capability_eval(
+                got, hb_seen = _run_capability_eval(
                     repo_root=repo_root,
                     run_root=run_root,
                     checkpoint=ckpt,
@@ -41,17 +45,20 @@ class TestAntRatioSweepEvalDevice(unittest.TestCase):
                     eval_seed_offset=1000003,
                     force_disjoint=True,
                     timeout_s=1,
+                    heartbeat_s=60,
                 )
 
             self.assertEqual(got, rep)
+            self.assertTrue(hb_seen)
             args, kwargs = mrun.call_args
             cmd = args[0]
             # cmd is a list of strings. Ensure '--device cpu' is present.
             self.assertIn("--device", cmd)
             didx = cmd.index("--device")
             self.assertEqual(cmd[didx + 1], "cpu")
+            hidx = cmd.index("--heartbeat-s")
+            self.assertEqual(cmd[hidx + 1], "60")
 
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/Golden Draft/tests/test_ant_ratio_sweep_eval_retry_once.py
+++ b/Golden Draft/tests/test_ant_ratio_sweep_eval_retry_once.py
@@ -1,0 +1,106 @@
+import csv
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import conftest  # noqa: F401  (import side-effect: sys.path bootstrap)
+
+
+class TestAntRatioSweepEvalRetryOnce(unittest.TestCase):
+    def test_missing_report_retries_once_and_succeeds(self) -> None:
+        from tools import ant_ratio_sweep_v0 as sweep
+        from tools import ant_ratio_packet_v0 as pktmod
+        from tools import ant_ratio_plot_v0 as pltmod
+
+        with tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+            out_root = td_path / "out"
+            batch_targets = td_path / "batch_targets.json"
+            batch_targets.write_text(
+                json.dumps({"rows": [{"ant_tier": "small", "expert_heads": 1, "chosen_batch": 2, "unusable": False}]}),
+                encoding="utf-8",
+            )
+
+            def _fake_probe(**kwargs):
+                out_dir = Path(kwargs["out_dir"])
+                out_dir.mkdir(parents=True, exist_ok=True)
+                return out_dir, {"stability_pass": True, "had_oom": False, "had_nan": False, "had_inf": False}
+
+            def _fake_train(**kwargs):
+                run_root = Path(kwargs["run_root"])
+                run_root.mkdir(parents=True, exist_ok=True)
+                ckpt = run_root / "checkpoint_last_good.pt"
+                ckpt.write_bytes(b"fake")
+                return ckpt, 0
+
+            def _fake_packet(**kwargs):
+                return {
+                    "schema_version": "ant_ratio_packet_v0",
+                    "git_commit": "fake",
+                    "generated_utc": "2026-02-07T00:00:00Z",
+                    "ant_tier": kwargs.get("ant_tier_override", "small"),
+                    "expert_heads": 1,
+                    "batch_size": 2,
+                    "precision": "fp16",
+                    "amp": 1,
+                    "vram_ratio_reserved": 0.84,
+                    "throughput_tokens_per_s": 100.0,
+                    "assoc_byte_disjoint_accuracy": 0.12,
+                    "assoc_eval_n": 512,
+                    "token_budget_steps": int(kwargs.get("capability_steps_override", 30)),
+                    "probe_run_root": str(kwargs.get("probe_run_root")),
+                    "assoc_run_root": str(kwargs.get("assoc_run_root")),
+                    "stability_pass": True,
+                    "fail_reasons": [],
+                }
+
+            run_root_box = {"path": None}
+
+            def _fake_eval(**kwargs):
+                run_root = Path(kwargs["run_root"])
+                run_root_box["path"] = run_root
+                if not (run_root / "retry.flag").exists():
+                    (run_root / "retry.flag").write_text("1", encoding="utf-8")
+                    raise sweep.SweepError(f"missing report.json after eval: {run_root / 'report.json'}")
+                rep = run_root / "report.json"
+                rep.write_text("{}", encoding="utf-8")
+                return rep, True
+
+            with (
+                mock.patch.dict(sys.modules, {"ant_ratio_packet_v0": pktmod, "ant_ratio_plot_v0": pltmod}),
+                mock.patch("tools.ant_ratio_sweep_v0._repo_root", return_value=td_path),
+                mock.patch("tools.ant_ratio_sweep_v0._run_probe", side_effect=_fake_probe),
+                mock.patch("tools.ant_ratio_sweep_v0._run_capability_train", side_effect=_fake_train),
+                mock.patch("tools.ant_ratio_sweep_v0._run_capability_eval", side_effect=_fake_eval),
+                mock.patch.object(pktmod, "build_packet", side_effect=_fake_packet),
+                mock.patch.object(pltmod, "build_html", return_value="<html></html>"),
+            ):
+                rc = sweep.main(
+                    [
+                        "--batch-targets",
+                        str(batch_targets),
+                        "--out-root",
+                        str(out_root),
+                        "--cap-eval-retry-once",
+                        "1",
+                    ]
+                )
+
+            self.assertEqual(rc, 0)
+            summary = out_root / "ant_ratio_summary.csv"
+            self.assertTrue(summary.exists())
+            with summary.open("r", encoding="utf-8", newline="") as f:
+                rows = list(csv.DictReader(f))
+            self.assertEqual(len(rows), 1)
+            row = rows[0]
+            self.assertEqual(row.get("status"), "ok")
+            self.assertEqual(row.get("attempt_eval_count"), "2")
+            self.assertEqual(row.get("eval_heartbeat_seen"), "True")
+            self.assertIsNotNone(run_root_box["path"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Golden Draft/tests/test_ant_ratio_sweep_nonzero_rc_checkpoint.py
+++ b/Golden Draft/tests/test_ant_ratio_sweep_nonzero_rc_checkpoint.py
@@ -1,3 +1,4 @@
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -43,6 +44,45 @@ class TestAntRatioSweepNonzeroRcCheckpoint(unittest.TestCase):
 
             self.assertEqual(got_ckpt, ckpt)
             self.assertEqual(got_rc, -1)
+
+    def test_timeout_uses_checkpoint(self) -> None:
+        from tools.ant_ratio_sweep_v0 import _run_capability_train
+
+        with tempfile.TemporaryDirectory() as td:
+            run_root = Path(td) / "assoc_run"
+            run_root.mkdir(parents=True, exist_ok=True)
+            ckpt = run_root / "checkpoint.pt"
+            ckpt.write_bytes(b"fake")
+
+            with mock.patch(
+                "tools.ant_ratio_sweep_v0.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd=["python"], timeout=1),
+            ):
+                got_ckpt, got_rc = _run_capability_train(
+                    repo_root=Path(td),
+                    run_root=run_root,
+                    seed=123,
+                    device="cpu",
+                    precision="fp32",
+                    ring_len=2048,
+                    slot_dim=256,
+                    expert_heads=1,
+                    batch=1,
+                    steps=5,
+                    synth_len=32,
+                    assoc_keys=4,
+                    assoc_pairs=2,
+                    assoc_val_range=8,
+                    max_samples=16,
+                    eval_samples=0,
+                    ptr_dtype="fp64",
+                    offline_only=True,
+                    save_every=1,
+                    timeout_s=1,
+                )
+
+            self.assertEqual(got_ckpt, ckpt)
+            self.assertEqual(got_rc, 124)
 
 
 if __name__ == "__main__":

--- a/Golden Draft/tests/test_eval_ckpt_heartbeat.py
+++ b/Golden Draft/tests/test_eval_ckpt_heartbeat.py
@@ -1,0 +1,28 @@
+import time
+import unittest
+
+import conftest  # noqa: F401  (import side-effect: sys.path bootstrap)
+
+
+class TestEvalCkptHeartbeat(unittest.TestCase):
+    def test_heartbeat_emits_pulses(self) -> None:
+        from tools.eval_ckpt_assoc_byte import _start_eval_heartbeat
+
+        logs = []
+
+        def _log(msg: str) -> None:
+            logs.append(str(msg))
+
+        stop, thread = _start_eval_heartbeat(_log, 1)
+        try:
+            time.sleep(2.2)
+        finally:
+            stop.set()
+            thread.join(timeout=1.0)
+
+        hb = [line for line in logs if "[eval_ckpt][heartbeat]" in line]
+        self.assertGreaterEqual(len(hb), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- hardens ant_ratio sweep for artifact-truth reliability
- adds watchdog-first eval mode (--cap-eval-timeout-s 0) and 60s eval heartbeat
- adds per-config flush + retry/recovery behaviors and regression tests

## Validation
- python -m unittest discover -s 'Golden Draft/tests' -p 'test_ant_ratio_*.py' -v
- python -m compileall 'Golden Draft/tools/ant_ratio_sweep_v0.py' 'Golden Draft/tools/eval_ckpt_assoc_byte.py'

## Notes
- Full 15-config VRA-78 run is executing under supervisor in local bench_vault _tmp root.