### PR TITLE
fix(docs): apply v5.0.0-beta.2 bump content

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository is meant to be a credible front door for technical buyers and en
 
 ## Release Snapshot
 
-- **Current public release tag:** [`v5.0.0-beta.1`](https://github.com/VRAXION/VRAXION/releases/tag/v5.0.0-beta.1) (released Rust language-evolution beta, 24.6% peak)
+- **Current public release tag:** [`v5.0.0-beta.2`](https://github.com/VRAXION/VRAXION/releases/tag/v5.0.0-beta.2) (released Rust language-evolution beta, 24.6% peak)
 - **Next public milestone:** grower-based `v5.0.0 Public Beta`
 - **Current mainline code path on `main`:** [`instnct-core/examples/neuron_grower.rs`](instnct-core/examples/neuron_grower.rs)
 - **Reference/support lane:** [`instnct/model/graph.py`](instnct/model/graph.py)

--- a/docs/VERSION.json
+++ b/docs/VERSION.json
@@ -1,5 +1,5 @@
 {
-  "current_release": "v5.0.0-beta.1",
+  "current_release": "v5.0.0-beta.2",
   "current_channel": "beta",
   "previous_stable": "v4.2.0",
   "internal_code_path": "instnct-core/",


### PR DESCRIPTION
## Summary
- Reconciles the empty `e2a56d2` commit (which had the right message but no file content change)
- Applies the actual beta.1 → beta.2 content update to:
  - `README.md` "Current public release tag" line
  - `docs/VERSION.json` `current_release` field

## Test plan
- [x] Verify `cat docs/VERSION.json` shows `"current_release": "v5.0.0-beta.2"`
- [x] Verify `grep 'beta\.1' README.md` returns only historical-context hits (Evidence snapshot's "Released beta.1 language-evolution result")

🤖 Generated with [Claude Code](https://claude.com/claude-code)