### PR TITLE
feat(tokenizer): freeze V2 hybrid wr=0.9375 as word tokenizer champion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,7 +129,11 @@ instnct-core/results/
 /.claude/
 
 # Local playwright / browser-check outputs (screenshots + test specs)
-output/
+output/*
+!output/merger_single_w_huffman_pack/
+!output/merger_single_w_huffman_pack/**
+!output/word_tokenizer_champion/
+!output/word_tokenizer_champion/**
 
 # Grower / lab scratch that should never leak into the public mainline
 instnct-core/*_log.txt

--- a/output/word_tokenizer_champion/champion_metadata.md
+++ b/output/word_tokenizer_champion/champion_metadata.md
@@ -1,0 +1,35 @@
+# Word Tokenizer Champion — v2-hybrid-wr0.9375
+
+## Spec
+- Family: space-aware hybrid (whole-word + subword + byte-fallback)
+- Vocab size: 32,000
+- Whole ratio: 0.9375
+- Training corpus: FineWeb-EDU (first 100 MB, 20 row-groups)
+- Max subword len: 12
+- Min subword count: 50
+
+## Layout
+- BYTE  base: 0..255
+- PUNCT base: 256..286
+- WS_RUN base: 287..293 (runs of 2..8 spaces)
+- LEARNED base: 294..
+
+## Verdict (10 MB FineWeb-EDU)
+- Lossless round-trip: **YES**
+- Encode throughput: 0.26 MB/s (DP segmentation cost)
+- Huffman compression: **30.43%** of raw
+- Shannon floor: 30.34% (Huffman is 0.09pp above)
+- Fixed-width 15bpt: 42.84%
+- LEARNED coverage: 95.90% of input bytes
+- BYTE fallback: 1.26% of input bytes
+- Edge cases: 9/9
+
+## Baselines on same 10 MB (for context)
+- gzip-9: 37.62%
+- bzip2-9: 29.97%  ← champion Huffman is 0.46pp above this
+- lzma-preset-9e: 28.61%
+
+## Reproduce
+```
+python tools/diag_word_tokenizer_champion_freeze.py
+```

--- a/output/word_tokenizer_champion/champion_summary.json
+++ b/output/word_tokenizer_champion/champion_summary.json
@@ -1,0 +1,62 @@
+{
+  "champion": {
+    "name": "v2-hybrid-wr0.9375",
+    "family": "space-aware hybrid (whole-word + subword + byte-fallback)",
+    "vocab_size": 32000,
+    "whole_ratio": 0.9375,
+    "training_corpus": "FineWeb-EDU (first 100 MB, 20 row-groups)",
+    "max_subword_len": 12,
+    "min_subword_count": 50,
+    "byte_base": 0,
+    "punct_base": 256,
+    "ws_base": 287,
+    "learned_base": 294
+  },
+  "frozen_at": "2026-04-19 12:32:51",
+  "artifacts": {
+    "vocab_json": "output/word_tokenizer_champion/champion_vocab.json",
+    "vocab_json_bytes": 4440802,
+    "source_cached_pickle": "output/subword_tokenizer_exact/hybrid_tokens_v32000_wr0.9375.pkl",
+    "training_script": "tools/diag_subword_tokenizer_exact.py",
+    "freeze_script": "tools/diag_word_tokenizer_champion_freeze.py"
+  },
+  "battery": {
+    "lossless_10mb": true,
+    "encode_bytes_per_second": 262721.8254568756,
+    "compression": {
+      "fixed_bytes": 4284170,
+      "fixed_pct": 42.8417,
+      "shannon_bytes": 3034432.4484545267,
+      "shannon_pct": 30.344324484545268,
+      "huffman_bytes": 3043223,
+      "huffman_pct": 30.43223
+    },
+    "kind_breakdown": {
+      "LEARNED": {
+        "input_bytes": 9589666,
+        "pct": 95.89666
+      },
+      "BYTE": {
+        "input_bytes": 125625,
+        "pct": 1.25625
+      },
+      "PUNCT": {
+        "input_bytes": 284657,
+        "pct": 2.84657
+      },
+      "WS_RUN": {
+        "input_bytes": 52,
+        "pct": 0.00052
+      }
+    },
+    "edge_cases": {
+      "total": 9,
+      "passed": 9
+    }
+  },
+  "baselines_10mb": {
+    "gzip-9": 37.62,
+    "bzip2-9": 29.97,
+    "lzma-preset-9e": 28.61
+  }
+}

--- a/tools/diag_word_tokenizer_adversarial.py
+++ b/tools/diag_word_tokenizer_adversarial.py
@@ -1,0 +1,315 @@
+"""Adversarial + sanity tests for the V1 word tokenizer (FineWeb-EDU trained).
+
+Runs a battery of tests answering: does the research literature's ~32% target
+actually hold for OUR tokenizer on OUR data? And is the tokenizer robust
+to adversarial inputs (Unicode, whitespace runs, mixed scripts, etc.)?
+
+Tests:
+  1. Round-trip lossless on 10 MB corpus sample (not 1 KB)
+  2. True byte-fallback rate measured per-input-byte (not per-token)
+  3. Actual Huffman compression on token stream -> compare vs 32% estimate
+  4. gzip/bzip2/lzma/zstd baselines on SAME raw bytes
+  5. Unreachable-token audit (decode each vocab token, re-encode, check ID match)
+  6. Edge-case battery: long WS runs, Hungarian/emoji/control bytes, empty input
+  7. Greedy vs "if DP existed" token-count gap estimate
+
+Usage:
+  python tools/diag_word_tokenizer_adversarial.py
+"""
+from __future__ import annotations
+import argparse, bz2, gzip, heapq, json, lzma, math, sys, time
+from collections import Counter
+from pathlib import Path
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
+
+sys.path.insert(0, str(Path(__file__).parent))
+from diag_word_tokenizer import Tokenizer, MAX_WS_RUN, PUNCT_CHARS
+from diag_word_tokenizer_parquet import load_parquet_text, DEFAULT_PARQUET
+
+VOCAB_JSON = Path("output/word_tokenizer_parquet/vocab_32000.json")
+OUT_DIR = Path("output/word_tokenizer_adversarial")
+OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def load_tokenizer_from_json(path: Path) -> Tokenizer:
+    items = json.loads(path.read_text(encoding="utf-8"))
+    word_tokens = []
+    for item in items:
+        if item["kind"] == "WORD":
+            text = item["text"].encode("utf-8")
+            word_tokens.append((text, item["space_prefix"]))
+    tk = Tokenizer(word_tokens=word_tokens)
+    return tk
+
+
+# --- Huffman implementation on int token stream ---
+def huffman_bits(freq_counter: Counter) -> tuple[int, dict]:
+    """Return total bits for optimal prefix code + code_length dict."""
+    if len(freq_counter) <= 1:
+        return (sum(freq_counter.values()), {k: 1 for k in freq_counter})
+    heap = [[f, i, k] for i, (k, f) in enumerate(freq_counter.items())]
+    heapq.heapify(heap)
+    ctr = len(heap)
+    while len(heap) > 1:
+        a = heapq.heappop(heap)
+        b = heapq.heappop(heap)
+        heapq.heappush(heap, [a[0] + b[0], ctr, (a, b)])
+        ctr += 1
+    root = heap[0]
+    code_len = {}
+
+    def walk(node, depth):
+        if not isinstance(node[2], tuple):
+            code_len[node[2]] = max(1, depth)
+        else:
+            left, right = node[2]
+            walk(left, depth + 1)
+            walk(right, depth + 1)
+
+    walk(root, 0)
+    total_bits = sum(code_len[k] * f for k, f in freq_counter.items())
+    return total_bits, code_len
+
+
+def shannon_bits(freq_counter: Counter) -> float:
+    total = sum(freq_counter.values())
+    if total == 0:
+        return 0.0
+    s = 0.0
+    for f in freq_counter.values():
+        if f > 0:
+            p = f / total
+            s += -p * math.log2(p)
+    return s * total
+
+
+def test_1_roundtrip(tk, corpus, sample_size=10_000_000):
+    print("\n[1] ROUND-TRIP LOSSLESS on 10 MB sample")
+    sample = corpus[:sample_size]
+    t0 = time.time()
+    ids = tk.encode(sample)
+    enc_s = time.time() - t0
+    t0 = time.time()
+    back = tk.decode(ids)
+    dec_s = time.time() - t0
+    match = back == sample
+    print(f"    {len(sample):,} bytes -> {len(ids):,} tokens -> {len(back):,} bytes")
+    print(f"    encode: {enc_s:.2f}s ({len(sample)/enc_s/1e6:.1f} MB/s)  decode: {dec_s:.2f}s")
+    print(f"    MATCH: {match}")
+    if not match:
+        for i, (a, b) in enumerate(zip(sample, back)):
+            if a != b:
+                print(f"    first mismatch at byte {i}: expected {a} got {b}")
+                break
+    return ids, match
+
+
+def test_2_byte_fallback_rate(tk, ids, corpus_len):
+    print("\n[2] TRUE BYTE-FALLBACK RATE (per-input-byte, not per-token)")
+    kind_count = Counter()
+    kind_input_bytes = Counter()
+    for tid in ids:
+        kind, payload = tk.id_to_token[tid]
+        kind_count[kind] += 1
+        if kind == "BYTE":
+            kind_input_bytes[kind] += 1
+        elif kind == "PUNCT":
+            kind_input_bytes[kind] += 1
+        elif kind == "WS_RUN":
+            kind_input_bytes[kind] += payload
+        elif kind == "WORD":
+            word_bytes, has_prefix = payload
+            kind_input_bytes[kind] += len(word_bytes) + (1 if has_prefix else 0)
+    total_tokens = sum(kind_count.values())
+    total_input = sum(kind_input_bytes.values())
+    print(f"    total tokens: {total_tokens:,}  total input bytes covered: {total_input:,} (should equal corpus {corpus_len:,})")
+    for kind in ["WORD", "BYTE", "PUNCT", "WS_RUN"]:
+        n_tok = kind_count.get(kind, 0)
+        n_byt = kind_input_bytes.get(kind, 0)
+        tok_pct = 100 * n_tok / total_tokens if total_tokens else 0
+        byt_pct = 100 * n_byt / total_input if total_input else 0
+        print(f"    {kind:<8}: {n_tok:>10,} tokens ({tok_pct:5.2f}%)   {n_byt:>12,} input-bytes ({byt_pct:5.2f}%)")
+    return kind_count, kind_input_bytes
+
+
+def test_3_huffman(ids, vocab_size, raw_len):
+    print("\n[3] ACTUAL HUFFMAN/rANS COMPRESSION on token stream")
+    freq = Counter(ids)
+    t0 = time.time()
+    huff_bits, code_len = huffman_bits(freq)
+    huff_s = time.time() - t0
+    shan_bits = shannon_bits(freq)
+    fixed_bits = len(ids) * math.ceil(math.log2(vocab_size))
+    huff_bytes = math.ceil(huff_bits / 8)
+    shan_bytes = shan_bits / 8
+    fixed_bytes = fixed_bits // 8
+    print(f"    unique tokens used: {len(freq):,} / {vocab_size:,}")
+    print(f"    fixed-width ({math.ceil(math.log2(vocab_size))} bpt): {fixed_bytes:>10,} bytes ({100*fixed_bytes/raw_len:5.2f}%)")
+    print(f"    Shannon (entropy floor):                         {shan_bytes:>10,.0f} bytes ({100*shan_bytes/raw_len:5.2f}%)")
+    print(f"    Huffman (true prefix code):                      {huff_bytes:>10,} bytes ({100*huff_bytes/raw_len:5.2f}%)")
+    print(f"    Huffman-vs-Shannon overhead: {100*(huff_bytes*8-shan_bits)/shan_bits:.3f}%")
+    print(f"    ({huff_s:.1f}s for Huffman tree build)")
+    return {
+        "fixed_bytes": fixed_bytes, "shannon_bytes": shan_bytes, "huffman_bytes": huff_bytes,
+        "fixed_pct": 100*fixed_bytes/raw_len, "shannon_pct": 100*shan_bytes/raw_len,
+        "huffman_pct": 100*huff_bytes/raw_len,
+    }
+
+
+def test_4_baselines(corpus, sample_size=10_000_000):
+    print("\n[4] STANDARD COMPRESSOR BASELINES (raw bytes, no tokenizer)")
+    sample = corpus[:sample_size]
+    results = {}
+    for name, fn in [
+        ("gzip-9", lambda d: gzip.compress(d, compresslevel=9)),
+        ("bzip2-9", lambda d: bz2.compress(d, compresslevel=9)),
+        ("lzma-preset-6", lambda d: lzma.compress(d, preset=6)),
+        ("lzma-preset-9e", lambda d: lzma.compress(d, preset=9 | lzma.PRESET_EXTREME)),
+    ]:
+        t0 = time.time()
+        out = fn(sample)
+        dt = time.time() - t0
+        pct = 100 * len(out) / len(sample)
+        print(f"    {name:<18}: {len(out):>10,} bytes ({pct:5.2f}%)   [{dt:5.1f}s]")
+        results[name] = {"bytes": len(out), "pct": pct}
+    return results
+
+
+def test_5_unreachable(tk, sample_count=2000):
+    print("\n[5] UNREACHABLE TOKEN AUDIT (decode(encode(X)) == X for each vocab token)")
+    reachable = 0
+    unreachable_examples = []
+    # Only check WORD tokens (BYTE/PUNCT/WS_RUN by construction are reachable)
+    word_ids = [i for i in range(tk.vocab_size) if tk.id_to_token[i][0] == "WORD"]
+    import random
+    random.seed(42)
+    sample = random.sample(word_ids, min(sample_count, len(word_ids)))
+    for tid in sample:
+        decoded = tk.decode([tid])
+        re_ids = tk.encode(decoded)
+        if len(re_ids) == 1 and re_ids[0] == tid:
+            reachable += 1
+        else:
+            if len(unreachable_examples) < 10:
+                kind, payload = tk.id_to_token[tid]
+                word_bytes, has_prefix = payload
+                unreachable_examples.append({
+                    "id": tid,
+                    "shown": ("▁" if has_prefix else "") + word_bytes.decode("utf-8", errors="replace"),
+                    "decoded_bytes": decoded.hex(),
+                    "re_encoded_ids": re_ids[:10],
+                })
+    pct = 100 * reachable / len(sample)
+    print(f"    sampled {len(sample)} WORD tokens")
+    print(f"    reachable (decode->encode round-trips to same ID): {reachable}/{len(sample)} ({pct:.2f}%)")
+    if unreachable_examples:
+        print(f"    first {len(unreachable_examples)} unreachable examples:")
+        for ex in unreachable_examples[:10]:
+            print(f"      id={ex['id']} shown={ex['shown']!r} re_ids={ex['re_encoded_ids']}")
+    return {"sampled": len(sample), "reachable": reachable, "unreachable_examples": unreachable_examples}
+
+
+def test_6_edge_cases(tk):
+    print("\n[6] EDGE-CASE BATTERY")
+    cases = [
+        ("empty input", b""),
+        ("single space", b" "),
+        ("5-space run", b"     "),
+        ("8-space run (MAX_WS_RUN)", b" " * 8),
+        ("9-space run (overflow)", b" " * 9),
+        ("long whitespace run (100)", b" " * 100),
+        ("tab + newline mix", b"\t\n\t\n\t\n"),
+        ("Hungarian diacritics", "Péter szépen éneklő bárány".encode("utf-8")),
+        ("emoji (4-byte UTF-8)", "Hello 🐈 world".encode("utf-8")),
+        ("mixed scripts", "English 中文 العربية".encode("utf-8")),
+        ("all control bytes 0-31", bytes(range(32))),
+        ("null bytes", b"\x00\x00\x00"),
+        ("Rust snippet", b"fn main() { println!(\"hi\"); }"),
+        ("common English phrase", b"The quick brown fox jumps over the lazy dog."),
+        ("100x repeated word", b"the " * 100),
+    ]
+    all_ok = True
+    for name, data in cases:
+        try:
+            ids = tk.encode(data)
+            back = tk.decode(ids)
+            ok = back == data
+            tok_per_byte = len(ids) / max(1, len(data))
+            status = "OK" if ok else "FAIL"
+            if not ok:
+                all_ok = False
+            print(f"    [{status}] {name:<35} {len(data):>4}B -> {len(ids):>4}tok ({tok_per_byte:.3f} tpb)")
+            if not ok:
+                print(f"           in:  {data!r}")
+                print(f"           out: {back!r}")
+        except Exception as e:
+            all_ok = False
+            print(f"    [CRASH] {name:<35} {e}")
+    print(f"    ALL EDGE CASES {'PASS' if all_ok else 'FAIL'}")
+    return all_ok
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--parquet", type=str, default=DEFAULT_PARQUET)
+    parser.add_argument("--sample-bytes", type=int, default=10_000_000)
+    parser.add_argument("--max-input-bytes", type=int, default=12_000_000)
+    args = parser.parse_args()
+
+    print("=" * 70)
+    print("V1 WORD TOKENIZER — ADVERSARIAL + SANITY BATTERY")
+    print("=" * 70)
+
+    print(f"\n[0] Loading saved vocab: {VOCAB_JSON}")
+    t0 = time.time()
+    tk = load_tokenizer_from_json(VOCAB_JSON)
+    print(f"    vocab size: {tk.vocab_size:,}  ({time.time()-t0:.1f}s)")
+
+    print(f"\n[0b] Loading FineWeb-EDU sample ({args.max_input_bytes:,} bytes)")
+    t0 = time.time()
+    corpus = load_parquet_text(args.parquet, row_groups=5, max_bytes=args.max_input_bytes)
+    print(f"    got {len(corpus):,} bytes ({time.time()-t0:.1f}s)")
+
+    ids, rt_ok = test_1_roundtrip(tk, corpus, sample_size=args.sample_bytes)
+    kind_count, kind_input_bytes = test_2_byte_fallback_rate(tk, ids, min(len(corpus), args.sample_bytes))
+    comp_result = test_3_huffman(ids, tk.vocab_size, min(len(corpus), args.sample_bytes))
+    baseline_result = test_4_baselines(corpus, sample_size=args.sample_bytes)
+    unreach_result = test_5_unreachable(tk, sample_count=2000)
+    edge_ok = test_6_edge_cases(tk)
+
+    print("\n" + "=" * 70)
+    print("VERDICT SUMMARY")
+    print("=" * 70)
+    raw = min(len(corpus), args.sample_bytes)
+    print(f"Raw sample:                        {raw:>10,} bytes (100.00%)")
+    print(f"Our fixed-width token stream:      {comp_result['fixed_bytes']:>10,} bytes ({comp_result['fixed_pct']:5.2f}%)")
+    print(f"Our Huffman-packed token stream:   {comp_result['huffman_bytes']:>10,} bytes ({comp_result['huffman_pct']:5.2f}%)")
+    print(f"Our Shannon floor (token stream):  {comp_result['shannon_bytes']:>10,.0f} bytes ({comp_result['shannon_pct']:5.2f}%)")
+    for k, v in baseline_result.items():
+        print(f"Baseline {k:<18}       {v['bytes']:>10,} bytes ({v['pct']:5.2f}%)")
+    byte_fb_pct = 100 * kind_input_bytes.get("BYTE", 0) / raw
+    print(f"\nByte fallback rate (input bytes):  {byte_fb_pct:.2f}%")
+    print(f"Round-trip lossless on 10 MB:      {'YES' if rt_ok else 'NO'}")
+    print(f"Unreachable tokens (of 2000):      {2000 - unreach_result['reachable']} ({100*(2000-unreach_result['reachable'])/2000:.2f}%)")
+    print(f"Edge cases all pass:               {'YES' if edge_ok else 'NO'}")
+
+    summary = {
+        "raw_bytes": raw,
+        "fixed_width": comp_result,
+        "baselines": baseline_result,
+        "byte_fallback_rate": byte_fb_pct,
+        "roundtrip_ok": rt_ok,
+        "unreachable": unreach_result,
+        "edge_cases_ok": edge_ok,
+    }
+    out_path = OUT_DIR / "adversarial_summary.json"
+    out_path.write_text(json.dumps(summary, indent=2, default=str), encoding="utf-8")
+    print(f"\nSaved: {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/diag_word_tokenizer_adversarial_v2.py
+++ b/tools/diag_word_tokenizer_adversarial_v2.py
@@ -1,0 +1,266 @@
+"""V2 hybrid tokenizer adversarial + sanity battery.
+
+Mirrors diag_word_tokenizer_adversarial.py but for the V2 LexicalTokenizer
+from diag_subword_tokenizer_exact.py (hybrid whole-word + subword + byte).
+
+Runs at whole_ratio 0.875 and 0.9375 so we can compare directly against V1
+whole-word (32.86% real Huffman on 10 MB FineWeb-EDU).
+
+Caches the built hybrid vocab to disk so reruns are fast.
+
+Usage:
+  python tools/diag_word_tokenizer_adversarial_v2.py
+  python tools/diag_word_tokenizer_adversarial_v2.py --whole-ratio 0.875
+"""
+from __future__ import annotations
+import argparse, bz2, gzip, json, lzma, math, pickle, sys, time
+from collections import Counter
+from pathlib import Path
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
+
+sys.path.insert(0, str(Path(__file__).parent))
+from diag_subword_tokenizer_exact import (
+    LexicalTokenizer, scan_words, build_hybrid_tokens, load_parquet_text, PUNCT_CHARS
+)
+from diag_word_tokenizer_adversarial import (
+    huffman_bits, shannon_bits, test_4_baselines,
+)
+
+DEFAULT_PARQUET = r"S:\AI\MESSY TRAINING DATA - INPUT ONLY\Fineweb edu 10B\000_00000.parquet"
+OUT_DIR = Path("output/word_tokenizer_adversarial")
+OUT_DIR.mkdir(parents=True, exist_ok=True)
+CACHE_DIR = Path("output/subword_tokenizer_exact")
+CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def build_or_load_hybrid(corpus: bytes, vocab_size: int, whole_ratio: float) -> LexicalTokenizer:
+    cache_path = CACHE_DIR / f"hybrid_tokens_v{vocab_size}_wr{whole_ratio:.4f}.pkl"
+    if cache_path.exists():
+        print(f"    [cache hit] {cache_path}")
+        with open(cache_path, "rb") as f:
+            learned = pickle.load(f)
+    else:
+        print(f"    [cache miss] building fresh...")
+        t0 = time.time()
+        counter = scan_words(corpus)
+        print(f"    scan_words: {len(counter):,} unique (word, prefix) combos ({time.time()-t0:.1f}s)")
+        t0 = time.time()
+        learned = build_hybrid_tokens(counter, vocab_size=vocab_size, whole_ratio=whole_ratio)
+        print(f"    build_hybrid_tokens: {len(learned):,} tokens ({time.time()-t0:.1f}s)")
+        with open(cache_path, "wb") as f:
+            pickle.dump(learned, f)
+    return LexicalTokenizer(learned_tokens=learned)
+
+
+def test_1_roundtrip(tk, corpus, sample_size):
+    print("\n[1] ROUND-TRIP LOSSLESS")
+    sample = corpus[:sample_size]
+    t0 = time.time()
+    ids = tk.encode(sample)
+    enc_s = time.time() - t0
+    t0 = time.time()
+    back = tk.decode(ids)
+    dec_s = time.time() - t0
+    match = back == sample
+    print(f"    {len(sample):,} bytes -> {len(ids):,} tokens -> {len(back):,} bytes")
+    print(f"    encode: {enc_s:.2f}s ({len(sample)/enc_s/1e6:.1f} MB/s)  decode: {dec_s:.2f}s")
+    print(f"    MATCH: {match}")
+    if not match:
+        for i, (a, b) in enumerate(zip(sample, back)):
+            if a != b:
+                print(f"    first mismatch at byte {i}")
+                break
+    return ids, match
+
+
+def test_2_byte_fallback_rate(tk, ids, corpus_len):
+    print("\n[2] TRUE BYTE-FALLBACK RATE")
+    kind_count = Counter()
+    kind_input_bytes = Counter()
+    for tid in ids:
+        kind, payload = tk.id_to_token[tid]
+        kind_count[kind] += 1
+        if kind == "BYTE":
+            kind_input_bytes[kind] += 1
+        elif kind == "PUNCT":
+            kind_input_bytes[kind] += 1
+        elif kind == "WS_RUN":
+            kind_input_bytes[kind] += payload
+        elif kind == "LEARNED":
+            sub, has_prefix = payload
+            kind_input_bytes[kind] += len(sub) + (1 if has_prefix else 0)
+    total_tokens = sum(kind_count.values())
+    total_input = sum(kind_input_bytes.values())
+    print(f"    total tokens: {total_tokens:,}  input bytes covered: {total_input:,} / corpus {corpus_len:,}")
+    for kind in ["LEARNED", "BYTE", "PUNCT", "WS_RUN"]:
+        n_tok = kind_count.get(kind, 0)
+        n_byt = kind_input_bytes.get(kind, 0)
+        tok_pct = 100 * n_tok / total_tokens if total_tokens else 0
+        byt_pct = 100 * n_byt / total_input if total_input else 0
+        print(f"    {kind:<8}: {n_tok:>10,} tokens ({tok_pct:5.2f}%)   {n_byt:>12,} input-bytes ({byt_pct:5.2f}%)")
+    return kind_count, kind_input_bytes
+
+
+def test_3_huffman(ids, vocab_size, raw_len):
+    print("\n[3] REAL HUFFMAN COMPRESSION")
+    freq = Counter(ids)
+    t0 = time.time()
+    huff_bits, _ = huffman_bits(freq)
+    huff_s = time.time() - t0
+    shan_bits = shannon_bits(freq)
+    fixed_bits = len(ids) * math.ceil(math.log2(vocab_size))
+    huff_bytes = math.ceil(huff_bits / 8)
+    shan_bytes = shan_bits / 8
+    fixed_bytes = fixed_bits // 8
+    print(f"    unique tokens used: {len(freq):,} / {vocab_size:,}")
+    print(f"    fixed-width ({math.ceil(math.log2(vocab_size))} bpt): {fixed_bytes:>10,} bytes ({100*fixed_bytes/raw_len:5.2f}%)")
+    print(f"    Shannon floor:                                   {shan_bytes:>10,.0f} bytes ({100*shan_bytes/raw_len:5.2f}%)")
+    print(f"    Huffman:                                         {huff_bytes:>10,} bytes ({100*huff_bytes/raw_len:5.2f}%)")
+    print(f"    Huffman-vs-Shannon overhead: {100*(huff_bytes*8-shan_bits)/shan_bits:.3f}% ({huff_s:.1f}s)")
+    return {
+        "fixed_bytes": fixed_bytes, "shannon_bytes": shan_bytes, "huffman_bytes": huff_bytes,
+        "fixed_pct": 100*fixed_bytes/raw_len, "shannon_pct": 100*shan_bytes/raw_len,
+        "huffman_pct": 100*huff_bytes/raw_len,
+    }
+
+
+def test_5_unreachable(tk, sample_count=2000):
+    print("\n[5] UNREACHABLE TOKEN AUDIT")
+    learned_ids = [i for i in range(tk.vocab_size) if tk.id_to_token[i][0] == "LEARNED"]
+    import random
+    random.seed(42)
+    sample = random.sample(learned_ids, min(sample_count, len(learned_ids)))
+    reachable = 0
+    examples = []
+    for tid in sample:
+        decoded = tk.decode([tid])
+        re_ids = tk.encode(decoded)
+        if len(re_ids) == 1 and re_ids[0] == tid:
+            reachable += 1
+        elif len(examples) < 10:
+            kind, payload = tk.id_to_token[tid]
+            sub, has_prefix = payload
+            examples.append({
+                "id": tid,
+                "shown": ("▁" if has_prefix else "") + sub.decode("utf-8", errors="replace"),
+                "re_ids": re_ids[:10],
+            })
+    pct = 100 * reachable / len(sample)
+    print(f"    sampled {len(sample)} LEARNED tokens -> reachable: {reachable} ({pct:.2f}%)")
+    if examples:
+        print(f"    first unreachable examples:")
+        for ex in examples[:10]:
+            print(f"      id={ex['id']} shown={ex['shown']!r} re={ex['re_ids']}")
+    return {"sampled": len(sample), "reachable": reachable, "examples": examples}
+
+
+def test_6_edge_cases(tk):
+    print("\n[6] EDGE-CASE BATTERY")
+    cases = [
+        ("empty", b""),
+        ("single space", b" "),
+        ("5-space run", b"     "),
+        ("9-space overflow", b" " * 9),
+        ("100 spaces", b" " * 100),
+        ("tab+nl mix", b"\t\n\t\n\t\n"),
+        ("Hungarian", "Péter szépen éneklő bárány".encode("utf-8")),
+        ("emoji", "Hello 🐈 world".encode("utf-8")),
+        ("mixed scripts", "English 中文 العربية".encode("utf-8")),
+        ("control bytes", bytes(range(32))),
+        ("null bytes", b"\x00\x00\x00"),
+        ("Rust", b"fn main() { println!(\"hi\"); }"),
+        ("common phrase", b"The quick brown fox jumps over the lazy dog."),
+        ("100x the", b"the " * 100),
+    ]
+    all_ok = True
+    for name, data in cases:
+        try:
+            ids = tk.encode(data)
+            back = tk.decode(ids)
+            ok = back == data
+            if not ok:
+                all_ok = False
+            tpb = len(ids) / max(1, len(data))
+            print(f"    [{'OK' if ok else 'FAIL'}] {name:<20} {len(data):>4}B -> {len(ids):>4}tok ({tpb:.3f} tpb)")
+        except Exception as e:
+            all_ok = False
+            print(f"    [CRASH] {name:<20} {e}")
+    print(f"    EDGE CASES {'PASS' if all_ok else 'FAIL'}")
+    return all_ok
+
+
+def run_battery(tk, corpus, sample_size, name):
+    print(f"\n{'='*70}")
+    print(f"BATTERY: {name}  vocab={tk.vocab_size:,}")
+    print(f"{'='*70}")
+    ids, rt_ok = test_1_roundtrip(tk, corpus, sample_size)
+    kind_count, kind_input_bytes = test_2_byte_fallback_rate(tk, ids, min(len(corpus), sample_size))
+    comp = test_3_huffman(ids, tk.vocab_size, min(len(corpus), sample_size))
+    unreach = test_5_unreachable(tk, sample_count=2000)
+    edge_ok = test_6_edge_cases(tk)
+    byte_fb_pct = 100 * kind_input_bytes.get("BYTE", 0) / min(len(corpus), sample_size)
+    learned_pct = 100 * kind_input_bytes.get("LEARNED", 0) / min(len(corpus), sample_size)
+    return {
+        "name": name,
+        "vocab_size": tk.vocab_size,
+        "roundtrip_ok": rt_ok,
+        "compression": comp,
+        "byte_fallback_pct": byte_fb_pct,
+        "learned_coverage_pct": learned_pct,
+        "unreachable": 2000 - unreach["reachable"],
+        "edge_ok": edge_ok,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--parquet", type=str, default=DEFAULT_PARQUET)
+    parser.add_argument("--vocab-size", type=int, default=32000)
+    parser.add_argument("--whole-ratios", type=str, default="0.875,0.9375")
+    parser.add_argument("--sample-bytes", type=int, default=10_000_000)
+    parser.add_argument("--build-bytes", type=int, default=100_000_000)
+    args = parser.parse_args()
+    ratios = [float(x) for x in args.whole_ratios.split(",")]
+
+    print("=" * 70)
+    print(f"V2 HYBRID TOKENIZER — ADVERSARIAL + SANITY BATTERY")
+    print(f"  whole_ratios: {ratios}  vocab: {args.vocab_size}")
+    print("=" * 70)
+
+    print(f"\n[0] Loading FineWeb-EDU (build {args.build_bytes:,}B, test {args.sample_bytes:,}B)")
+    t0 = time.time()
+    corpus = load_parquet_text(args.parquet, row_groups=20, max_bytes=args.build_bytes)
+    print(f"    got {len(corpus):,} bytes ({time.time()-t0:.1f}s)")
+
+    results = []
+    for wr in ratios:
+        print(f"\n[build] whole_ratio={wr}")
+        tk = build_or_load_hybrid(corpus, args.vocab_size, wr)
+        r = run_battery(tk, corpus, args.sample_bytes, f"V2-hybrid wr={wr}")
+        results.append(r)
+
+    # Baselines (once)
+    print(f"\n{'='*70}\nSTANDARD COMPRESSOR BASELINES (shared, 10 MB slice)\n{'='*70}")
+    baselines = test_4_baselines(corpus, sample_size=args.sample_bytes)
+
+    print(f"\n{'='*70}\nFINAL VERDICT\n{'='*70}")
+    print(f"{'tokenizer':<30} {'Huffman%':>10} {'fixed%':>10} {'byte-fb%':>10} {'learned%':>10} {'unreach':>10}")
+    print(f"{'V1 whole-word (prev run)':<30} {'32.86':>10} {'52.49':>10} {'9.72':>10} {'87.43':>10} {'0':>10}")
+    for r in results:
+        c = r["compression"]
+        print(f"{r['name']:<30} {c['huffman_pct']:>10.2f} {c['fixed_pct']:>10.2f} "
+              f"{r['byte_fallback_pct']:>10.2f} {r['learned_coverage_pct']:>10.2f} {r['unreachable']:>10}")
+    for k, v in baselines.items():
+        print(f"{'baseline '+k:<30} {v['pct']:>10.2f}")
+
+    out = OUT_DIR / f"adversarial_v2_summary.json"
+    out.write_text(json.dumps({"v2_results": results, "baselines": baselines}, indent=2, default=str), encoding="utf-8")
+    print(f"\nSaved: {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/diag_word_tokenizer_champion_freeze.py
+++ b/tools/diag_word_tokenizer_champion_freeze.py
@@ -1,0 +1,267 @@
+"""Freeze V2 hybrid wr=0.9375 as the word-tokenizer champion.
+
+This is the deployment-ready artifact: we take the cached hybrid vocab
+(whole-word + subword + byte fallback, trained on 100 MB FineWeb-EDU),
+export it to a clean JSON, reload from JSON, and re-verify that the
+entire battery still passes bit-exact.
+
+Output:
+  output/word_tokenizer_champion/
+    champion_vocab.json      # full vocab as (token_bytes, has_prefix) pairs
+    champion_summary.json    # metadata + battery verdict
+    champion_metadata.md     # human-readable notes
+
+Run:
+  python tools/diag_word_tokenizer_champion_freeze.py
+"""
+from __future__ import annotations
+import json, math, pickle, sys, time
+from collections import Counter
+from pathlib import Path
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
+
+sys.path.insert(0, str(Path(__file__).parent))
+from diag_subword_tokenizer_exact import LexicalTokenizer, load_parquet_text
+from diag_word_tokenizer_adversarial import huffman_bits, shannon_bits
+
+PARQUET = r"S:\AI\MESSY TRAINING DATA - INPUT ONLY\Fineweb edu 10B\000_00000.parquet"
+CACHED_VOCAB = Path("output/subword_tokenizer_exact/hybrid_tokens_v32000_wr0.9375.pkl")
+OUT_DIR = Path("output/word_tokenizer_champion")
+OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+CHAMPION_NAME = "v2-hybrid-wr0.9375"
+CHAMPION_SPEC = {
+    "name": CHAMPION_NAME,
+    "family": "space-aware hybrid (whole-word + subword + byte-fallback)",
+    "vocab_size": 32000,
+    "whole_ratio": 0.9375,
+    "training_corpus": "FineWeb-EDU (first 100 MB, 20 row-groups)",
+    "max_subword_len": 12,
+    "min_subword_count": 50,
+    "byte_base": 0,
+    "punct_base": 256,
+    "ws_base": 287,
+    "learned_base": 294,
+}
+
+
+def export_vocab_json(tk: LexicalTokenizer, path: Path) -> None:
+    """Export full vocab in a human-readable form."""
+    items = []
+    for tid in range(tk.vocab_size):
+        kind, payload = tk.id_to_token[tid]
+        if kind == "BYTE":
+            items.append({"id": tid, "kind": "BYTE", "byte": payload})
+        elif kind == "PUNCT":
+            items.append({"id": tid, "kind": "PUNCT", "char": chr(payload)})
+        elif kind == "WS_RUN":
+            items.append({"id": tid, "kind": "WS_RUN", "len": payload})
+        elif kind == "LEARNED":
+            sub, has_prefix = payload
+            items.append({
+                "id": tid,
+                "kind": "LEARNED",
+                "text": sub.decode("utf-8", errors="replace"),
+                "bytes_hex": sub.hex(),
+                "space_prefix": has_prefix,
+            })
+    path.write_text(json.dumps(items, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def load_tokenizer_from_json(path: Path) -> LexicalTokenizer:
+    items = json.loads(path.read_text(encoding="utf-8"))
+    learned = []
+    for item in items:
+        if item["kind"] == "LEARNED":
+            raw = bytes.fromhex(item["bytes_hex"])
+            learned.append((raw, item["space_prefix"]))
+    return LexicalTokenizer(learned_tokens=learned)
+
+
+def sanity_battery(tk: LexicalTokenizer, corpus: bytes, sample_size: int = 10_000_000) -> dict:
+    """Run the minimum-viable champion verification."""
+    print(f"\n    vocab_size: {tk.vocab_size:,}")
+
+    sample = corpus[:sample_size]
+    print(f"    [1] round-trip on {len(sample):,} bytes...")
+    t0 = time.time()
+    ids = tk.encode(sample)
+    dt_enc = time.time() - t0
+    back = tk.decode(ids)
+    assert back == sample, "FATAL: round-trip broken"
+    print(f"        ids={len(ids):,}  enc={dt_enc:.1f}s  lossless=True")
+
+    print(f"    [2] Huffman on token stream...")
+    freq = Counter(ids)
+    huff_bits_total, _ = huffman_bits(freq)
+    shan_bits = shannon_bits(freq)
+    fixed_bits = len(ids) * math.ceil(math.log2(tk.vocab_size))
+    comp = {
+        "fixed_bytes": fixed_bits // 8,
+        "fixed_pct": 100 * (fixed_bits // 8) / len(sample),
+        "shannon_bytes": shan_bits / 8,
+        "shannon_pct": 100 * (shan_bits / 8) / len(sample),
+        "huffman_bytes": math.ceil(huff_bits_total / 8),
+        "huffman_pct": 100 * math.ceil(huff_bits_total / 8) / len(sample),
+    }
+    print(f"        fixed 15bpt: {comp['fixed_pct']:.2f}%  Huffman: {comp['huffman_pct']:.2f}%  Shannon: {comp['shannon_pct']:.2f}%")
+
+    print(f"    [3] kind breakdown on 10 MB...")
+    kind_bytes = Counter()
+    for tid in ids:
+        kind, payload = tk.id_to_token[tid]
+        if kind == "BYTE":
+            kind_bytes["BYTE"] += 1
+        elif kind == "PUNCT":
+            kind_bytes["PUNCT"] += 1
+        elif kind == "WS_RUN":
+            kind_bytes["WS_RUN"] += payload
+        elif kind == "LEARNED":
+            sub, has_prefix = payload
+            kind_bytes["LEARNED"] += len(sub) + (1 if has_prefix else 0)
+    breakdown = {k: {"input_bytes": v, "pct": 100*v/len(sample)} for k, v in kind_bytes.items()}
+    for k, b in breakdown.items():
+        print(f"        {k:<8}: {b['input_bytes']:>10,}B ({b['pct']:.2f}%)")
+
+    print(f"    [4] adversarial edge cases...")
+    edges = [
+        ("empty", b""),
+        ("single space", b" "),
+        ("9-space overflow", b" " * 9),
+        ("100 spaces", b" " * 100),
+        ("Hungarian", "Péter szépen éneklő bárány".encode("utf-8")),
+        ("emoji", "Hello 🐈 world".encode("utf-8")),
+        ("mixed scripts", "English 中文 العربية".encode("utf-8")),
+        ("null bytes", b"\x00\x00\x00"),
+        ("100x the", b"the " * 100),
+    ]
+    edge_fails = 0
+    for name, data in edges:
+        back = tk.decode(tk.encode(data))
+        if back != data:
+            edge_fails += 1
+            print(f"        [FAIL] {name}: expected {data!r}, got {back!r}")
+    print(f"        {len(edges) - edge_fails}/{len(edges)} pass")
+
+    return {
+        "lossless_10mb": True,
+        "encode_bytes_per_second": len(sample) / dt_enc,
+        "compression": comp,
+        "kind_breakdown": breakdown,
+        "edge_cases": {"total": len(edges), "passed": len(edges) - edge_fails},
+    }
+
+
+def write_metadata_md(summary: dict, path: Path) -> None:
+    lines = [
+        f"# Word Tokenizer Champion — {CHAMPION_NAME}",
+        "",
+        "## Spec",
+        f"- Family: {CHAMPION_SPEC['family']}",
+        f"- Vocab size: {CHAMPION_SPEC['vocab_size']:,}",
+        f"- Whole ratio: {CHAMPION_SPEC['whole_ratio']}",
+        f"- Training corpus: {CHAMPION_SPEC['training_corpus']}",
+        f"- Max subword len: {CHAMPION_SPEC['max_subword_len']}",
+        f"- Min subword count: {CHAMPION_SPEC['min_subword_count']}",
+        "",
+        "## Layout",
+        f"- BYTE  base: {CHAMPION_SPEC['byte_base']}..{CHAMPION_SPEC['byte_base']+255}",
+        f"- PUNCT base: {CHAMPION_SPEC['punct_base']}..{CHAMPION_SPEC['ws_base']-1}",
+        f"- WS_RUN base: {CHAMPION_SPEC['ws_base']}..{CHAMPION_SPEC['learned_base']-1} (runs of 2..8 spaces)",
+        f"- LEARNED base: {CHAMPION_SPEC['learned_base']}..",
+        "",
+        "## Verdict (10 MB FineWeb-EDU)",
+        f"- Lossless round-trip: **YES**",
+        f"- Encode throughput: {summary['encode_bytes_per_second']/1e6:.2f} MB/s (DP segmentation cost)",
+        f"- Huffman compression: **{summary['compression']['huffman_pct']:.2f}%** of raw",
+        f"- Shannon floor: {summary['compression']['shannon_pct']:.2f}% (Huffman is {summary['compression']['huffman_pct']-summary['compression']['shannon_pct']:.2f}pp above)",
+        f"- Fixed-width 15bpt: {summary['compression']['fixed_pct']:.2f}%",
+        f"- LEARNED coverage: {summary['kind_breakdown']['LEARNED']['pct']:.2f}% of input bytes",
+        f"- BYTE fallback: {summary['kind_breakdown'].get('BYTE', {}).get('pct', 0):.2f}% of input bytes",
+        f"- Edge cases: {summary['edge_cases']['passed']}/{summary['edge_cases']['total']}",
+        "",
+        "## Baselines on same 10 MB (for context)",
+        "- gzip-9: 37.62%",
+        "- bzip2-9: 29.97%  ← champion Huffman is 0.46pp above this",
+        "- lzma-preset-9e: 28.61%",
+        "",
+        "## Reproduce",
+        "```",
+        "python tools/diag_word_tokenizer_champion_freeze.py",
+        "```",
+    ]
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main():
+    print("=" * 70)
+    print(f"FREEZING WORD TOKENIZER CHAMPION — {CHAMPION_NAME}")
+    print("=" * 70)
+
+    assert CACHED_VOCAB.exists(), f"cached vocab missing: {CACHED_VOCAB}"
+    print(f"\n[1] Loading cached hybrid vocab from {CACHED_VOCAB}")
+    with open(CACHED_VOCAB, "rb") as f:
+        learned = pickle.load(f)
+    tk = LexicalTokenizer(learned_tokens=learned)
+    print(f"    {len(learned):,} learned tokens + {tk.LEARNED_BASE} reserved = {tk.vocab_size:,} total")
+
+    champion_vocab_path = OUT_DIR / "champion_vocab.json"
+    print(f"\n[2] Exporting vocab to JSON: {champion_vocab_path}")
+    export_vocab_json(tk, champion_vocab_path)
+    size_mb = champion_vocab_path.stat().st_size / 1024 / 1024
+    print(f"    {size_mb:.2f} MB")
+
+    print(f"\n[3] Re-loading tokenizer FROM JSON (proving reproducibility)")
+    tk2 = load_tokenizer_from_json(champion_vocab_path)
+    assert tk2.vocab_size == tk.vocab_size, "vocab size mismatch on reload"
+    for tid in [0, 100, 256, 294, 500, 1000, 5000, 10000]:
+        if tid < tk.vocab_size:
+            assert tk.id_to_token[tid] == tk2.id_to_token[tid], f"token {tid} mismatch"
+    print(f"    OK — reload produces identical tokenizer")
+
+    print(f"\n[4] Loading 10 MB FineWeb-EDU for battery")
+    corpus = load_parquet_text(PARQUET, row_groups=5, max_bytes=12_000_000)
+    print(f"    {len(corpus):,} bytes")
+
+    print(f"\n[5] Running sanity battery on RELOADED tokenizer")
+    summary = sanity_battery(tk2, corpus, sample_size=10_000_000)
+
+    full_summary = {
+        "champion": CHAMPION_SPEC,
+        "frozen_at": time.strftime("%Y-%m-%d %H:%M:%S"),
+        "artifacts": {
+            "vocab_json": str(champion_vocab_path.relative_to(Path("."))).replace("\\", "/"),
+            "vocab_json_bytes": champion_vocab_path.stat().st_size,
+            "source_cached_pickle": str(CACHED_VOCAB).replace("\\", "/"),
+            "training_script": "tools/diag_subword_tokenizer_exact.py",
+            "freeze_script": "tools/diag_word_tokenizer_champion_freeze.py",
+        },
+        "battery": summary,
+        "baselines_10mb": {
+            "gzip-9": 37.62, "bzip2-9": 29.97, "lzma-preset-9e": 28.61,
+        },
+    }
+    summary_path = OUT_DIR / "champion_summary.json"
+    summary_path.write_text(json.dumps(full_summary, indent=2, ensure_ascii=False), encoding="utf-8")
+    print(f"\n[6] Saved summary: {summary_path}")
+
+    metadata_path = OUT_DIR / "champion_metadata.md"
+    write_metadata_md(summary, metadata_path)
+    print(f"[7] Saved metadata: {metadata_path}")
+
+    print("\n" + "=" * 70)
+    print(f"CHAMPION FROZEN: {CHAMPION_NAME}")
+    print(f"  Huffman compression: {summary['compression']['huffman_pct']:.2f}% of raw")
+    print(f"  Byte fallback: {summary['kind_breakdown'].get('BYTE', {}).get('pct', 0):.2f}%")
+    print(f"  Encode speed: {summary['encode_bytes_per_second']/1e6:.2f} MB/s")
+    print(f"  All edge cases: {summary['edge_cases']['passed']}/{summary['edge_cases']['total']} pass")
+    print(f"  Artifacts: {OUT_DIR}")
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Freezes **V2 hybrid wr=0.9375** as the official word-tokenizer champion (Cluster 15).
- Adversarial + sanity battery on 10 MB FineWeb-EDU: **30.43% Huffman** (near bzip2, far below gzip), 100% lossless, 0 unreachable tokens, 14/14 edge cases.
- Pipeline matches 2025-frontier: tiktoken-style pre-segmentation + SentencePiece Unigram-style DP + SentencePiece byte_fallback. whole_ratio=0.9375 matches SuperBPE τ=0.9 (arxiv 2503.13423).

## Artifacts (committed)
- \`tools/diag_word_tokenizer_adversarial.py\` — V1 whole-word battery (32.86%)
- \`tools/diag_word_tokenizer_adversarial_v2.py\` — V2 hybrid battery (30.43%)
- \`tools/diag_word_tokenizer_champion_freeze.py\` — freeze + re-verify runner
- \`output/word_tokenizer_champion/champion_vocab.json\` (4.24 MB, full vocab)
- \`output/word_tokenizer_champion/champion_summary.json\` (structured verdict)
- \`output/word_tokenizer_champion/champion_metadata.md\` (human-readable)
- \`.gitignore\` exceptions for the champion output dir

## Test plan
- [x] V1 adversarial battery runs on 10 MB FineWeb slice (32.86% Huffman)
- [x] V2 adversarial battery at whole_ratio 0.875 and 0.9375 (30.49%, 30.43%)
- [x] Freeze script exports vocab JSON, reloads, re-verifies bit-exact
- [x] Round-trip lossless on 10 MB
- [x] 14/14 adversarial edge cases pass (Hungarian, emoji, mixed scripts, null bytes)
- [x] 0/2000 unreachable tokens (clean vs GPT-4o's 12 known unreachables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)