### PR TITLE
feat(structure): scaffold Python/ and Rust/ deploy-SDK folders

### DIFF
--- a/Python/README.md
+++ b/Python/README.md
@@ -1,0 +1,27 @@
+# VRAXION Python Deploy SDK
+
+Clean, minimal Python library exposing the **frozen byte-level pipeline** as a simple API.
+
+## What goes here
+
+Only the **deploy-ready winning components** — no research code, no diagnostic scripts. Currently planned:
+
+| component | source artifact | status |
+|---|---|---|
+| L0 Byte Encoder | `tools/byte_embedder_lut.h` (256-entry LUT, 4.1 KB) | frozen, pending port |
+| L1 Byte-Pair Merger | `output/merger_single_w_huffman_pack/packed_model.bin` (3.36 KB Huffman-packed) | frozen, pending port |
+| Word Tokenizer V2 | `output/word_tokenizer_champion/champion_vocab.json` (32,294 slots, 4.24 MB) | frozen, pending port |
+| Embedder V1 | `output/word_embedding_v1/` | scaffold — awaits training |
+| Nano Brain V1 | `output/nano_brain_v1/` | scaffold — awaits training |
+
+## What does NOT go here
+
+- Research / diagnostic scripts — those stay in `tools/`
+- Python experimental package — that stays in `instnct/`
+- Unfinished scaffolds or exploratory ports
+
+## Status
+
+**Under construction.** First port (byte encoder) is the next step. Until then, this folder is a placeholder for the deployment target.
+
+The sibling [`Rust/`](../Rust/) folder will hold the identical pipeline in Rust; both SDKs are backed by the same champion artifacts in `output/`.

--- a/Rust/README.md
+++ b/Rust/README.md
@@ -1,0 +1,26 @@
+# VRAXION Rust Deploy SDK
+
+Clean, minimal Rust crate exposing the **frozen byte-level pipeline** as a simple API.
+
+## What goes here
+
+Only the **deploy-ready winning components** — no research code, no experimental examples. Currently planned:
+
+| component | source artifact | status |
+|---|---|---|
+| L0 Byte Encoder | `tools/byte_embedder_lut.h` (256-entry LUT, 4.1 KB) | frozen, pending port |
+| L1 Byte-Pair Merger | `output/merger_single_w_huffman_pack/packed_model.bin` (3.36 KB Huffman-packed) | frozen, pending port |
+| Word Tokenizer V2 | `output/word_tokenizer_champion/champion_vocab.json` (32,294 slots, 4.24 MB) | frozen, pending port |
+| Embedder V1 | `output/word_embedding_v1/` | scaffold — awaits training |
+| Nano Brain V1 | `output/nano_brain_v1/` | scaffold — awaits training |
+
+## What does NOT go here
+
+- `instnct-core/` stays separate — it is the **Rust research mainline** (bias-free threshold grower, scout oracle, quantization championship, etc.), not the byte-level deploy SDK.
+- Experimental Rust examples — those stay in `instnct-core/examples/`.
+
+## Status
+
+**Under construction.** First port (byte encoder) is the next step. Until then, this folder is a placeholder for the deployment target.
+
+The sibling [`Python/`](../Python/) folder holds the identical pipeline in Python; both SDKs are backed by the same champion artifacts in `output/`.


### PR DESCRIPTION
## Summary
Creates two new top-level folders that will hold the **deployable byte-level pipeline** in matched Python and Rust form. No code yet — only placeholder READMEs marking the intent.

## Rationale
As the byte-level pipeline (L0 + L1 + Tokenizer V2 + future Embedder + Brain) matures, we want a clean split between:
- **Research surface** (\`tools/\`, \`instnct/\`, \`instnct-core/\`) — scratch scripts, experimental examples, research package
- **Deploy surface** (\`Python/\`, \`Rust/\`) — minimal consumers of the frozen champion artifacts in \`output/\`

Both SDK folders share the same on-disk artifacts (no duplication); they differ only in language-specific API surface.

## What is NOT in this PR
- No code ports yet — placeholders only
- No changes to existing folders (\`tools/\`, \`instnct/\`, \`instnct-core/\` untouched)
- No CI / wiki / doc updates — those come when code lands

## Incremental follow-ups
1. byte_encoder port → Python/ and Rust/
2. merger port → Python/ and Rust/
3. tokenizer port → Python/ and Rust/
4. embedder + brain ports (after training)

## Test plan
- [x] Two new folders exist with clear READMEs
- [x] No disruption to existing repo structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)