### PR TITLE
chore(tools): commit negative-finding diagnostics from full-binary exploration

### DIFF
--- a/tools/diag_byte_unit_binary_variants_sweep.py
+++ b/tools/diag_byte_unit_binary_variants_sweep.py
@@ -1,0 +1,213 @@
+"""Binary variants sweep — find which float components are CRITICAL.
+
+The pure-binary (no biases, no alphas, sign activation, binary LUT) sweep
+produced max 32/256 exact at H=24 — it does not converge. To find the
+minimum configuration that DOES work, sweep variants with progressively
+fewer float components:
+
+Variants (all have binary W1, W2):
+  A: C19 activation, float biases, float alphas, int8 LUT     (current champion)
+  B: C19 activation, float biases, float alphas, BINARY LUT   (force binary output)
+  C: SIGN activation, float biases, float alphas, BINARY LUT
+  D: SIGN activation, NO biases,    float alphas, BINARY LUT
+  E: SIGN activation, NO biases,    NO alphas,    BINARY LUT   (pure — expected to fail)
+
+For each variant, sweep H in [16, 24, 32, 48, 64] and report best lossless H.
+"""
+from __future__ import annotations
+import argparse, json, math, sys, time
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
+
+sys.path.insert(0, str(Path(__file__).parent))
+from diag_byte_unit_widen_sweep import (
+    DEVICE, CODEBOOKS, FloatByteUnit, QuantByteUnit,
+    build_dataset, metrics, train_adam, choose_best_alpha_pair,
+    init_quant_from_float, load_winner_blob, warm_start_from_winner,
+)
+from diag_byte_unit_full_binary_sweep import FullBinaryByteUnit, stesign, STEsign
+
+OUT_DIR = Path("output/byte_unit_binary_variants_sweep")
+OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+class BinaryWithBiasSignLUT(nn.Module):
+    """Variant C: binary W1/W2 + sign activation + float biases + alphas + binary LUT."""
+    def __init__(self, hidden: int):
+        super().__init__()
+        self.hidden = hidden
+        self.W1 = nn.Parameter(torch.empty(8, hidden, device=DEVICE))
+        self.W2 = nn.Parameter(torch.empty(hidden, 16, device=DEVICE))
+        self.b1 = nn.Parameter(torch.zeros(hidden, device=DEVICE))
+        self.b2 = nn.Parameter(torch.zeros(16, device=DEVICE))
+        self.alpha1_raw = nn.Parameter(torch.tensor(0.0, device=DEVICE))
+        self.alpha2_raw = nn.Parameter(torch.tensor(0.0, device=DEVICE))
+        nn.init.uniform_(self.W1, -1.0, 1.0)
+        nn.init.uniform_(self.W2, -1.0, 1.0)
+
+    @property
+    def alpha1(self):
+        return F.softplus(self.alpha1_raw) + 1e-6
+    @property
+    def alpha2(self):
+        return F.softplus(self.alpha2_raw) + 1e-6
+
+    def W1_bin(self):
+        return stesign(self.W1) * self.alpha1
+    def W2_bin(self):
+        return stesign(self.W2) * self.alpha2
+
+    def encode(self, x):
+        h_pre = x @ self.W1_bin() + self.b1
+        h = stesign(h_pre)  # sign activation
+        z_pre = h @ self.W2_bin() + self.b2
+        z = stesign(z_pre)  # BINARY LUT
+        return z
+
+    def decode(self, z):
+        W2_b = self.W2_bin()
+        W1_b = self.W1_bin()
+        return (z @ W2_b.t()) @ W1_b.t()
+
+    def forward(self, x):
+        z = self.encode(x)
+        x_hat = self.decode(z)
+        return z, x_hat
+
+
+class BinaryNoBiasSignLUT(nn.Module):
+    """Variant D: binary W1/W2 + sign activation + NO biases + alphas + binary LUT."""
+    def __init__(self, hidden: int):
+        super().__init__()
+        self.hidden = hidden
+        self.W1 = nn.Parameter(torch.empty(8, hidden, device=DEVICE))
+        self.W2 = nn.Parameter(torch.empty(hidden, 16, device=DEVICE))
+        self.alpha1_raw = nn.Parameter(torch.tensor(0.0, device=DEVICE))
+        self.alpha2_raw = nn.Parameter(torch.tensor(0.0, device=DEVICE))
+        nn.init.uniform_(self.W1, -1.0, 1.0)
+        nn.init.uniform_(self.W2, -1.0, 1.0)
+
+    @property
+    def alpha1(self):
+        return F.softplus(self.alpha1_raw) + 1e-6
+    @property
+    def alpha2(self):
+        return F.softplus(self.alpha2_raw) + 1e-6
+
+    def W1_bin(self):
+        return stesign(self.W1) * self.alpha1
+    def W2_bin(self):
+        return stesign(self.W2) * self.alpha2
+
+    def encode(self, x):
+        h = stesign(x @ self.W1_bin())
+        z = stesign(h @ self.W2_bin())
+        return z
+
+    def decode(self, z):
+        return (z @ self.W2_bin().t()) @ self.W1_bin().t()
+
+    def forward(self, x):
+        z = self.encode(x)
+        x_hat = self.decode(z)
+        return z, x_hat
+
+
+def measure(model, x):
+    model.eval()
+    with torch.no_grad():
+        z, x_hat = model(x)
+    signs = torch.sign(x_hat); signs[signs == 0] = 1.0
+    match = (signs == x).all(dim=1)
+    exact = int(match.sum().item())
+    # unique
+    z_bits = ((z + 1) / 2).long()
+    flat = torch.zeros(z.size(0), dtype=torch.long, device=DEVICE)
+    for j in range(z.size(1)):
+        flat = flat * 2 + z_bits[:, j]
+    uniq = int(torch.unique(flat).numel())
+    return exact, uniq
+
+
+def train_variant(cls, hidden, epochs=1500, lr=5e-3, restarts=4, seed=42):
+    x = build_dataset()
+    best = {"exact": -1, "uniq": 0}
+    for r in range(restarts):
+        torch.manual_seed(seed + r * 13 + hidden * 7)
+        model = cls(hidden).to(DEVICE)
+        opt = torch.optim.Adam(model.parameters(), lr=lr)
+        for ep in range(epochs):
+            z, x_hat = model(x)
+            loss = F.mse_loss(x_hat, x)
+            opt.zero_grad(); loss.backward(); opt.step()
+        exact, uniq = measure(model, x)
+        if exact > best["exact"]:
+            best = {"exact": exact, "uniq": uniq, "restart": r, "loss": float(loss.item())}
+            if exact == 256:
+                break
+    return best
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--hiddens", default="16,24,32,48,64,96")
+    parser.add_argument("--epochs", type=int, default=1500)
+    parser.add_argument("--restarts", type=int, default=4)
+    args = parser.parse_args()
+    hiddens = [int(s) for s in args.hiddens.split(",")]
+
+    variants = [
+        ("C_bias_sign_binLUT", BinaryWithBiasSignLUT),
+        ("D_nobias_sign_binLUT", BinaryNoBiasSignLUT),
+    ]
+
+    print("=" * 70)
+    print("BINARY VARIANTS SWEEP — find smallest config reaching 256/256")
+    print("=" * 70)
+
+    results = {}
+    for var_name, cls in variants:
+        print(f"\n[{var_name}]")
+        var_results = []
+        for h in hiddens:
+            t0 = time.time()
+            res = train_variant(cls, h, epochs=args.epochs, restarts=args.restarts)
+            res["hidden"] = h
+            res["time_s"] = time.time() - t0
+            var_results.append(res)
+            mark = "✓" if res["exact"] == 256 else " "
+            print(f"  {mark} H={h:>3d}  exact={res['exact']:>3d}/256  uniq={res['uniq']:>3d}  "
+                  f"({res['time_s']:.1f}s, r={res['restart']})")
+            if res["exact"] == 256:
+                break
+        results[var_name] = var_results
+
+    print("\n" + "=" * 70)
+    print("VERDICT")
+    print("=" * 70)
+    for var_name, var_res in results.items():
+        lossless = [r for r in var_res if r["exact"] == 256]
+        if lossless:
+            min_h = min(r["hidden"] for r in lossless)
+            print(f"  {var_name}: min H = {min_h}")
+        else:
+            best = max(var_res, key=lambda r: r["exact"])
+            print(f"  {var_name}: NO lossless in sweep (best: H={best['hidden']}, {best['exact']}/256)")
+
+    out_path = OUT_DIR / "variants_summary.json"
+    out_path.write_text(json.dumps({"hiddens": hiddens, "epochs": args.epochs,
+                                     "restarts": args.restarts, "results": results}, indent=2), encoding="utf-8")
+    print(f"\n  Saved: {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/diag_byte_unit_full_binary_sweep.py
+++ b/tools/diag_byte_unit_full_binary_sweep.py
@@ -1,0 +1,247 @@
+"""Full-binary byte unit minimum H sweep.
+
+Not just binary WEIGHTS — binary EVERYTHING:
+  - W1, W2: binary {-1, +1}
+  - hidden activation: sign function (binary output)
+  - LUT output: binary (sign-snapped)
+  - NO biases, NO alpha scales, NO C19, NO float anywhere in the forward path
+
+Question: what is the smallest H that keeps the full-binary pipeline 256/256
+lossless? If any H works, that's a ~10x size reduction over the current
+binary-weights + int8-LUT champion.
+
+Architecture:
+  x in {-1, +1}^8
+    -> W1 (8 x H, binary)
+    -> sign()
+    -> h in {-1, +1}^H
+    -> W2 (H x 16, binary)
+    -> sign()
+    -> z in {-1, +1}^16   (this IS the LUT entry, binary)
+  decode: z @ W2.T @ W1.T -> take sign to recover byte bits
+
+Training: STE (straight-through estimator) for both sign() and binary
+weight quantization. Adam on float shadow weights; forward uses binary.
+
+Storage if successful at H=X:
+  W1:  8 * X bits
+  W2:  X * 16 bits
+  LUT: 256 * 16 bits = 512 B (same regardless of X)
+  total binary L0 = W1 + W2 + 512 B
+
+Usage:
+  python tools/diag_byte_unit_full_binary_sweep.py
+"""
+from __future__ import annotations
+import argparse, json, math, sys, time
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
+
+DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+OUT_DIR = Path("output/byte_unit_full_binary_sweep")
+OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def build_dataset() -> torch.Tensor:
+    """256 x 8 bipolar bit vectors for each byte 0..255."""
+    bytes_idx = torch.arange(256, dtype=torch.long, device=DEVICE)
+    bits = torch.stack([(bytes_idx >> i) & 1 for i in range(8)], dim=1).float()
+    return bits * 2.0 - 1.0  # {-1, +1}
+
+
+class STEsign(torch.autograd.Function):
+    """Straight-through sign: forward sign, backward identity."""
+    @staticmethod
+    def forward(ctx, x):
+        ctx.save_for_backward(x)
+        out = torch.sign(x)
+        out[out == 0] = 1.0
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_out):
+        (x,) = ctx.saved_tensors
+        # clip gradient where input is too large (optional; keeps training stable)
+        mask = (x.abs() <= 1.0).float()
+        return grad_out * mask
+
+
+def stesign(x):
+    return STEsign.apply(x)
+
+
+class FullBinaryByteUnit(nn.Module):
+    """Everything binary: W1, W2, activation, output."""
+    def __init__(self, hidden: int):
+        super().__init__()
+        self.hidden = hidden
+        # Float "shadow" weights that get STE-binarized on the forward pass.
+        self.W1_shadow = nn.Parameter(torch.empty(8, hidden, device=DEVICE))
+        self.W2_shadow = nn.Parameter(torch.empty(hidden, 16, device=DEVICE))
+        nn.init.uniform_(self.W1_shadow, -1.0, 1.0)
+        nn.init.uniform_(self.W2_shadow, -1.0, 1.0)
+
+    def W1_bin(self):
+        return stesign(self.W1_shadow)
+
+    def W2_bin(self):
+        return stesign(self.W2_shadow)
+
+    def encode(self, x: torch.Tensor) -> torch.Tensor:
+        # x in {-1, +1}^8
+        h_pre = x @ self.W1_bin()   # (B, H)
+        h = stesign(h_pre)           # binary hidden
+        z_pre = h @ self.W2_bin()    # (B, 16)
+        z = stesign(z_pre)           # BINARY LUT entry
+        return z
+
+    def decode(self, z: torch.Tensor) -> torch.Tensor:
+        # tied mirror decode, produces 8-dim float (take sign for byte)
+        return (z @ self.W2_bin().t()) @ self.W1_bin().t()
+
+    def forward(self, x):
+        z = self.encode(x)
+        x_hat = self.decode(z)
+        return z, x_hat
+
+
+def measure_exact(model: FullBinaryByteUnit, x: torch.Tensor) -> tuple[int, int]:
+    """Return (bytes_exact, unique_latents)."""
+    model.eval()
+    with torch.no_grad():
+        z, x_hat = model(x)
+    signs = torch.sign(x_hat)
+    signs[signs == 0] = 1.0
+    per_byte_match = (signs == x).all(dim=1)
+    bytes_exact = int(per_byte_match.sum().item())
+    # unique latents: count unique rows in z (binary)
+    z_bits = ((z + 1) / 2).long()  # {0, 1}
+    z_flat = torch.zeros(z.size(0), dtype=torch.long, device=DEVICE)
+    for j in range(z.size(1)):
+        z_flat = z_flat * 2 + z_bits[:, j]
+    uniq = int(torch.unique(z_flat).numel())
+    return bytes_exact, uniq
+
+
+def train_one(hidden: int, epochs: int = 2000, lr: float = 5e-3, seed: int = 42,
+              restart_n: int = 3) -> dict:
+    """Train full-binary byte unit at given H, try a few random restarts."""
+    x = build_dataset()
+    best = {"bytes_exact": -1, "unique_latents": 0, "hidden": hidden}
+    for r in range(restart_n):
+        torch.manual_seed(seed + r * 13 + hidden * 7)
+        model = FullBinaryByteUnit(hidden).to(DEVICE)
+        opt = torch.optim.Adam(model.parameters(), lr=lr)
+        for ep in range(epochs):
+            z, x_hat = model(x)
+            # L2 reconstruction loss; since x is bipolar and x_hat is signed,
+            # this encourages x_hat to align with x.
+            loss_recon = F.mse_loss(x_hat, x)
+            # Mild "separation" term: penalize duplicate z vectors.
+            # (Optional; helps training avoid the all-same-latent trap.)
+            z_bits = ((z + 1) / 2)
+            # pairwise bit-similarity — want low on average (not identical)
+            z_flat = z_bits.reshape(256, -1)
+            sep_penalty = (z_flat @ z_flat.t() / z_flat.size(1) - 0.5).pow(2).mean() * 0.1
+            loss = loss_recon + sep_penalty
+            opt.zero_grad()
+            loss.backward()
+            opt.step()
+
+        exact, uniq = measure_exact(model, x)
+        if exact > best["bytes_exact"]:
+            best = {
+                "bytes_exact": exact,
+                "unique_latents": uniq,
+                "hidden": hidden,
+                "restart": r,
+                "final_loss": float(loss.item()),
+            }
+            if exact == 256:
+                break  # early exit on perfect
+
+    return best
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--hiddens", default="16,24,32,48,64,96,128,160,192,256")
+    parser.add_argument("--epochs", type=int, default=2000)
+    parser.add_argument("--lr", type=float, default=5e-3)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--restarts", type=int, default=3)
+    args = parser.parse_args()
+
+    hiddens = [int(s) for s in args.hiddens.split(",")]
+    print("=" * 70)
+    print("FULL-BINARY BYTE UNIT MINIMUM-H SWEEP")
+    print("  everything binary: W1, W2, activation, LUT. no biases, no scale.")
+    print(f"  hiddens={hiddens}  epochs={args.epochs}  restarts={args.restarts}")
+    print("=" * 70)
+
+    results = []
+    for h in hiddens:
+        t0 = time.time()
+        res = train_one(h, epochs=args.epochs, lr=args.lr, seed=args.seed,
+                        restart_n=args.restarts)
+        res["time_s"] = time.time() - t0
+        results.append(res)
+        mark = "✓" if res["bytes_exact"] == 256 else " "
+        print(f"  {mark} H={h:>4d}  exact={res['bytes_exact']:>3d}/256  "
+              f"uniq_latents={res['unique_latents']:>3d}/256  "
+              f"({res['time_s']:.1f}s, restart={res.get('restart',0)})")
+        if res["bytes_exact"] == 256:
+            # Found a lossless H — can stop (but continue to check if smaller also works)
+            pass
+
+    # Find minimum H that was 100% exact
+    lossless = [r for r in results if r["bytes_exact"] == 256]
+    print("\n" + "=" * 70)
+    print("VERDICT")
+    print("=" * 70)
+    if lossless:
+        min_h = min(r["hidden"] for r in lossless)
+        print(f"  Minimum H for 100% full-binary lossless: {min_h}")
+        print(f"  Storage at H={min_h}:")
+        W1_bits = 8 * min_h
+        W2_bits = min_h * 16
+        LUT_bits = 256 * 16
+        total = (W1_bits + W2_bits + LUT_bits) / 8
+        print(f"    W1:  {W1_bits/8:.0f} B  ({W1_bits} bits)")
+        print(f"    W2:  {W2_bits/8:.0f} B  ({W2_bits} bits)")
+        print(f"    LUT: {LUT_bits/8:.0f} B  ({LUT_bits} bits)")
+        print(f"    total: {total:.0f} B")
+        print(f"  vs current binary-weights+int8-LUT champion: ~10,500 B")
+        print(f"  reduction: {100*(1 - total/10500):.1f}%")
+    else:
+        best = max(results, key=lambda r: r["bytes_exact"])
+        print(f"  NO H in the sweep reached 100% full-binary lossless.")
+        print(f"  Best: H={best['hidden']}, {best['bytes_exact']}/256 exact.")
+        print(f"  This means full-binary (with no biases, no scale, no C19) may need:")
+        print(f"    - larger H (extend sweep)")
+        print(f"    - longer training")
+        print(f"    - or keeping SOME float components (biases / alpha / activation scale)")
+
+    out_path = OUT_DIR / "sweep_summary.json"
+    out_path.write_text(json.dumps({
+        "sweep_hiddens": hiddens,
+        "epochs": args.epochs,
+        "lr": args.lr,
+        "restarts": args.restarts,
+        "results": results,
+        "lossless_hiddens": [r["hidden"] for r in lossless],
+    }, indent=2), encoding="utf-8")
+    print(f"\n  Saved: {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/diag_byte_unit_lut_precision_sweep.py
+++ b/tools/diag_byte_unit_lut_precision_sweep.py
@@ -1,0 +1,234 @@
+"""Test: what's the smallest LUT precision that preserves 100% lossless?
+
+We have binary weights already. The baked LUT is int8. The question: can we
+quantize the LUT values themselves down (int4, int2, int1) and still have
+the tied-mirror decoder reconstruct all 256 bytes correctly?
+
+Tests each precision by:
+  1. Loading the frozen binary+C19+H=16 champion
+  2. Encoding all 256 bytes -> (256, 16) float LUT
+  3. Quantizing the LUT to N levels (int8, int4, int2, int1)
+  4. Running the decoder on the quantized LUT
+  5. Checking byte reconstruction (256/256?)
+
+If binary (int1) still gives 256/256, then the DEPLOY LUT can be 512 B.
+
+Usage:
+  python tools/diag_byte_unit_lut_precision_sweep.py
+"""
+from __future__ import annotations
+import json, math, sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
+
+sys.path.insert(0, str(Path(__file__).parent))
+from diag_byte_unit_widen_sweep import (
+    DEVICE, CODEBOOKS, QuantByteUnit, build_dataset, metrics,
+)
+
+CHAMPION_DIR = Path("output/byte_unit_champion_binary_c19_h16")
+OUT_DIR = Path("output/byte_unit_lut_precision_sweep")
+OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+HIDDEN = 16
+ACTIVATION = "c19"
+CODEBOOK_NAME = "binary"
+CODEBOOK = CODEBOOKS[CODEBOOK_NAME]
+
+
+def reload_champion():
+    blob = json.loads((CHAMPION_DIR / "byte_unit_winner_binary.json").read_text(encoding="utf-8"))
+    model = QuantByteUnit(HIDDEN, ACTIVATION, CODEBOOK).to(DEVICE)
+
+    W1_idx = np.array(blob["W1_binary_idx"], dtype=np.int64)
+    W1_levels = np.array(blob["W1_levels"], dtype=np.float32)
+    W1 = W1_levels[W1_idx]
+    W2_idx = np.array(blob["W2_binary_idx"], dtype=np.int64)
+    W2_levels = np.array(blob["W2_levels"], dtype=np.float32)
+    W2 = W2_levels[W2_idx]
+
+    with torch.no_grad():
+        model.W1.copy_(torch.tensor(W1, device=DEVICE))
+        model.W2.copy_(torch.tensor(W2, device=DEVICE))
+        model.b1.copy_(torch.tensor(blob["b1"], device=DEVICE))
+        model.b2.copy_(torch.tensor(blob["b2"], device=DEVICE))
+        a1_raw = math.log(math.exp(blob["alpha1"]) - 1)
+        a2_raw = math.log(math.exp(blob["alpha2"]) - 1)
+        model.alpha1_raw.copy_(torch.tensor(a1_raw, device=DEVICE))
+        model.alpha2_raw.copy_(torch.tensor(a2_raw, device=DEVICE))
+        for name, p in model.act.named_parameters():
+            p.copy_(torch.tensor(blob["activation_params"][name], device=DEVICE))
+
+    return model
+
+
+def quantize_symmetric(lut: np.ndarray, bits: int) -> tuple[np.ndarray, float]:
+    """Symmetric linear quantization to signed N-bit integer range."""
+    if bits == 8:
+        levels = 127  # int8: -127..+127
+    elif bits == 4:
+        levels = 7    # int4: -7..+7
+    elif bits == 2:
+        levels = 1    # int2: -1, +1 (actually this is -1..+1 range)
+    elif bits == 1:
+        levels = 1    # int1: -1, +1 signum-like
+    else:
+        raise ValueError(f"unsupported bits: {bits}")
+
+    absmax = float(np.abs(lut).max())
+    if absmax == 0:
+        return lut.astype(np.int32), 1.0
+    scale = absmax / levels
+    q = np.round(lut / scale).clip(-levels, levels)
+    return q.astype(np.int32), scale
+
+
+def quantize_binary_sign(lut: np.ndarray) -> tuple[np.ndarray, float]:
+    """Pure binary: sign(lut) * mean_abs per dim."""
+    mean_abs = float(np.abs(lut).mean())
+    signs = np.sign(lut).astype(np.int32)
+    # Handle zeros by mapping to +1
+    signs[signs == 0] = 1
+    return signs, mean_abs
+
+
+def quantize_ternary(lut: np.ndarray) -> tuple[np.ndarray, float]:
+    """Ternary: map to {-1, 0, +1} based on magnitude threshold."""
+    absmax = float(np.abs(lut).max())
+    thr = absmax / 3  # heuristic threshold
+    q = np.zeros_like(lut, dtype=np.int32)
+    q[lut > thr] = 1
+    q[lut < -thr] = -1
+    scale = absmax / 1
+    return q, scale
+
+
+def decode_via_lut(lut: torch.Tensor, model) -> torch.Tensor:
+    """Decode a (256, 16) LUT back to (256, 8) bit-signs via the model's decoder."""
+    with torch.no_grad():
+        x_hat = model.decode(lut)  # (256, 8)
+    return x_hat
+
+
+def byte_match(x_hat_signs: np.ndarray, x_orig: np.ndarray) -> int:
+    """Count how many of 256 bytes decode correctly."""
+    # x_orig is (256, 8) with -1/+1 per bit
+    # x_hat_signs is predicted signs
+    # Bytes match iff all 8 signs match
+    match_per_byte = (x_hat_signs == x_orig).all(axis=1)
+    return int(match_per_byte.sum())
+
+
+def main():
+    print("=" * 70)
+    print("LUT PRECISION SWEEP — how low can we go and keep 256/256 lossless?")
+    print("=" * 70)
+
+    print(f"\n[1] Loading binary+C19+H=16 champion from {CHAMPION_DIR}")
+    model = reload_champion()
+    model.eval()
+
+    x = build_dataset()  # (256, 8) with -1/+1 per bit
+    x_np = x.cpu().numpy()
+    m = metrics(model, x)
+    print(f"    weight-reload lossless: {m['lossless']:.2f}% (sanity)")
+
+    with torch.no_grad():
+        float_lut = model.encode(x).cpu().numpy()  # (256, 16) float
+    print(f"    float LUT shape: {float_lut.shape}  range: [{float_lut.min():+.3f}, {float_lut.max():+.3f}]")
+
+    results = []
+
+    for bits in [8, 4, 2, 1]:
+        q_lut, scale = quantize_symmetric(float_lut, bits)
+        dequant = q_lut.astype(np.float32) * scale
+        dequant_t = torch.tensor(dequant, device=DEVICE)
+        x_hat = decode_via_lut(dequant_t, model).cpu().numpy()
+        x_hat_signs = np.sign(x_hat).astype(np.int32)
+        x_hat_signs[x_hat_signs == 0] = 1
+        matches = byte_match(x_hat_signs, x_np.astype(np.int32))
+        # Size calc
+        raw_bytes = 256 * 16 * bits / 8
+        print(f"  [symmetric int{bits}]: {matches:>3d}/256 bytes OK  "
+              f"raw LUT = {raw_bytes:>5.0f} B  scale={scale:.4e}")
+        results.append({
+            "method": f"symmetric_int{bits}",
+            "bits_per_value": bits,
+            "bytes_decoded": matches,
+            "lossless": matches == 256,
+            "raw_lut_bytes": int(raw_bytes),
+            "scale": float(scale),
+        })
+
+    # Try sign-based binary (different from symmetric_int1)
+    q_bin, mean_abs = quantize_binary_sign(float_lut)
+    dequant = q_bin.astype(np.float32) * mean_abs
+    dequant_t = torch.tensor(dequant, device=DEVICE)
+    x_hat = decode_via_lut(dequant_t, model).cpu().numpy()
+    x_hat_signs = np.sign(x_hat).astype(np.int32)
+    x_hat_signs[x_hat_signs == 0] = 1
+    matches = byte_match(x_hat_signs, x_np.astype(np.int32))
+    print(f"  [binary sign]:          {matches:>3d}/256 bytes OK  "
+          f"raw LUT = {256*16/8:>5.0f} B  (1 bit per value)")
+    results.append({
+        "method": "binary_sign",
+        "bits_per_value": 1,
+        "bytes_decoded": matches,
+        "lossless": matches == 256,
+        "raw_lut_bytes": 256*16//8,
+        "scale": float(mean_abs),
+    })
+
+    # Try ternary
+    q_tern, scale_t = quantize_ternary(float_lut)
+    dequant = q_tern.astype(np.float32) * scale_t
+    dequant_t = torch.tensor(dequant, device=DEVICE)
+    x_hat = decode_via_lut(dequant_t, model).cpu().numpy()
+    x_hat_signs = np.sign(x_hat).astype(np.int32)
+    x_hat_signs[x_hat_signs == 0] = 1
+    matches = byte_match(x_hat_signs, x_np.astype(np.int32))
+    print(f"  [ternary]:              {matches:>3d}/256 bytes OK  "
+          f"raw LUT ~= {256*16*1.585/8:>5.0f} B packed")
+    results.append({
+        "method": "ternary",
+        "bits_per_value": 1.585,
+        "bytes_decoded": matches,
+        "lossless": matches == 256,
+        "raw_lut_bytes_packed": int(256*16*1.585/8),
+        "scale": float(scale_t),
+    })
+
+    print("\n" + "=" * 70)
+    print("VERDICT — smallest lossless LUT precision")
+    print("=" * 70)
+    lossless_opts = [r for r in results if r["lossless"]]
+    if lossless_opts:
+        smallest = min(lossless_opts, key=lambda r: r.get("raw_lut_bytes", 99999))
+        print(f"  Lossless methods found: {len(lossless_opts)}")
+        for r in lossless_opts:
+            raw_b = r.get("raw_lut_bytes", r.get("raw_lut_bytes_packed", "?"))
+            print(f"    - {r['method']:<20} {raw_b} B raw")
+        print(f"\n  SMALLEST LOSSLESS: {smallest['method']} -> {smallest.get('raw_lut_bytes', smallest.get('raw_lut_bytes_packed'))} B")
+        print(f"  vs current int8 LUT: 4096 B")
+    else:
+        print(f"  NO method below int8 stayed lossless. The int8 LUT is minimum for this decoder.")
+        best = max(results, key=lambda r: r["bytes_decoded"])
+        print(f"  Best non-lossless: {best['method']} -> {best['bytes_decoded']}/256")
+
+    out_path = OUT_DIR / "precision_sweep.json"
+    out_path.write_text(json.dumps({
+        "champion": "binary + C19 + H=16",
+        "results": results,
+    }, indent=2), encoding="utf-8")
+    print(f"\n  Saved: {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Three tool scripts authored during today's full-binary exploration, kept as evidence backing the Cluster 17 decision to stick with the binary-weights + C19 + int8-LUT champion.

## Scripts
- `diag_byte_unit_full_binary_sweep.py` — fully binary (no biases, no scale, sign activation, binary LUT): peak 32/256 at H=24; does not converge.
- `diag_byte_unit_binary_variants_sweep.py` — variants C (with biases) and D (no biases): peak 28-36/256; neither converges.
- `diag_byte_unit_lut_precision_sweep.py` — tests LUT precision floor on the champion: int8 is minimum; int4 gets 247/256, int2/int1 collapse.

## Test plan
- [x] All three scripts run without error
- [x] Results JSON outputs land under `output/` (gitignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)