### PR TITLE
docs: add AnchorWeave AnchorCell setup wiki page

### DIFF
--- a/docs/wiki/AnchorWeave-AnchorCell-Setup.md
+++ b/docs/wiki/AnchorWeave-AnchorCell-Setup.md
@@ -1,0 +1,304 @@
+# AnchorWeave / AnchorCell Setup
+
+Status snapshot: 2026-05-09.
+
+This page is the default handoff surface for the AnchorWeave / AnchorCell line. It records what exists, what was tested, what failed, what is currently locked, and what should not be repeated.
+
+## Current Status
+
+- AnchorWeave scaffold exists on `main`.
+- Canonical storage is rich append-only AnchorCell JSONL.
+- Real or private cells must stay private unless explicitly sanitized.
+- Current experimental status: the scaffold is valid, but the AnchorWeave format-effect is not proven.
+- AWFT-001 synthetic navigation tests were useful as measurement infrastructure, but they did not justify scaling human AnchorCell collection.
+- Later HF/LoRA and forced-choice work has been built and tested as experimental runner work; keep it separate from the stable AnchorCell storage contract until merged and reviewed.
+
+## Claim Boundary
+
+AnchorWeave is not a dataset of consciousness.
+
+AnchorWeave is not proof of grounding at scale.
+
+AnchorWeave is infrastructure for operational symbol-grounding research via relational episodic anchors:
+
+```text
+episode -> relational graph -> salience -> action/outcome -> counterfactuals
+-> memory hook -> pre-symbol abstraction -> symbol attach/reject
+```
+
+The working thesis remains:
+
+```text
+Do not ground the symbol directly.
+Store relational episodic anchors from which stable abstractions can emerge.
+Symbols attach late.
+```
+
+## What Was Built
+
+Stable scaffold on `main`:
+
+- AnchorCell schema and taxonomy.
+- Two sanitized example cells.
+- Dataset README and dataset card.
+- Collection protocol and full dataset spec.
+- Validator, append tool, and export skeleton.
+- Private-data `.gitignore` rules.
+- AWFT-001 deterministic synthetic A/B scaffold for navigation / route-memory disambiguation.
+
+Experimental runner work:
+
+- HF/LoRA same-base training runner.
+- HF structured-output inference audit path.
+- AWFT-001-FC forced-choice runner that removes model-generated JSON from the measurement path.
+- Local run artifacts and scoreboards under ignored `target/`.
+
+## What We Learned
+
+JSON-generation evaluation failed as a measurement path because output format compliance was unstable. The model could run through the pipeline, but invalid or malformed structured output made the grounding result hard to interpret.
+
+Forced-choice NLL scoring works better as a measurement surface:
+
+```text
+prompt + candidate completion -> candidate-token loss
+```
+
+This removes parser, schema, markdown, and missing-field noise. It does not prove recall. It only measures preference among supplied candidate plans, so it must be paired with free-response and adversarial baselines.
+
+AWFT-001-FC result was negative:
+
+- Rich prose beat AnchorWeave on raw candidate accuracy.
+- AnchorWeave improved over plain QA, but did not beat rich prose.
+- Prior-corrected scoring collapsed toward shortcut candidates.
+- Shuffled AnchorWeave failed as expected.
+
+Conclusion:
+
+```text
+The current synthetic AnchorWeave navigation setup did not prove a format-effect.
+Do not scale human AnchorCell collection from that result.
+```
+
+## Current Default Direction
+
+Do not scale human AnchorCell collection yet.
+
+Do not keep expanding synthetic AWFT navigation as the main line.
+
+Move to human-grounded microtests with gradient value/cost scoring:
+
+- small number of carefully locked cells,
+- explicit human search judgment,
+- adversarial controls,
+- forced-choice plus free-response audit,
+- mean value remaining as the primary metric.
+
+The next default probe is `HGA-DESK-001 / DeskCache S01`.
+
+## Locked Next Cell: HGA-DESK-001 / DeskCache S01
+
+Task:
+
+```text
+Economical search for a USB drive on a cluttered desk.
+```
+
+Hidden truth:
+
+```text
+The USB drive is plugged into the keyboard side USB port.
+```
+
+Primary metric:
+
+```text
+mean_value_remaining
+```
+
+Exact accuracy is secondary. The point is not only whether the model chooses the gold plan, but how much search energy it wastes if it chooses a plausible trap.
+
+Four prompt arms:
+
+```text
+BASE
+STYLE_CONTROL
+CORRECT_ANCHOR
+CORRUPTED_ANCHOR
+```
+
+Required probes:
+
+```text
+forced-choice NLL
+choices-only baseline
+free-response audit
+pairwise trap checks
+candidate paraphrase check
+```
+
+## S01 Lock Rules
+
+- `BASE` must not reveal the keyboard-side port.
+- `CORRECT_ANCHOR` must not mention `keyboard`, `port`, `plugged`, or `monitor`.
+- `STYLE_CONTROL` must match form and approximate length, but must not include domain-specific search policy.
+- `CORRUPTED_ANCHOR` must be fluent and plausible, but semantically wrong.
+- Candidate plans must be complete first-search plans, not single labels.
+- Candidate order must be randomized by seed and scored by `candidate_id`, never by position.
+- No assistant-call option. The assistant is unreachable.
+- No mounted-drive option in S01. Make that a sibling cell if needed.
+- Candidate text must be length/style balanced.
+- The gold candidate must not be shorter than the traps.
+- The gold candidate must not reuse exact anchor phrases such as `ready-to-use` or `hand-work area`.
+- Do not repeat the gold fallback phrase inside every wrong candidate. Use a neutral fallback like `continue with the remaining desk search`.
+- Report a choices-only baseline. If the gold candidate wins without the scene or note, the cell is invalid as a grounding probe.
+
+## Current S01 Cell Contract
+
+Desk layout:
+
+```text
+Back row:
+- wallet on the left
+- monitor in the center
+- pen cup on the right
+
+Middle:
+- keyboard
+- ashtray with cigarette butts and tiny trash
+- cigarette pack and lighter beside the ashtray
+
+Front:
+- mouse
+- microphone
+- small electronics pouch
+- closed USB holder stand
+```
+
+The pen cup is crowded with pens, paper clips, erasers, SD cards, and small unrecognized bits. The USB holder stand is visible, but its front slot looks empty and too shallow for this USB drive to sit there properly.
+
+Assistant note:
+
+```text
+I didn't really put the USB away. The little holder was not a good fit for it,
+and I did not want it mixed with the other USB-looking junk where you would
+never spot it. I also would not leave it where ash, ink, graphite, or pocket
+dirt could mess it up, and I would never go into the wallet where you keep
+your money. I left it somewhere it could be useful quickly, near the part of
+the desk your hands return to. Think less like storage, and more like
+ready-to-use.
+```
+
+Task framing:
+
+```text
+You are looking for the USB with as little wasted searching as possible.
+Your assistant is not reachable right now, so you cannot ask them directly.
+Choose the best first search plan.
+```
+
+Candidate plans:
+
+| candidate_id | candidate text pattern | cost | value_remaining | trap_type |
+|---|---|---:|---:|---|
+| `keyboard_side_port_first` | Check the keyboard's side USB port first; if it is not there, continue with the remaining desk search. | 1 | 9 | `gold` |
+| `monitor_ports_first` | Check the monitor's USB ports first; if it is not there, continue with the remaining desk search. | 3 | 7 | `plausible_peripheral` |
+| `usb_holder_first` | Check the USB holder stand first; if it is not there, continue with the remaining desk search. | 2 | 8 | `surface_association` |
+| `electronics_pouch_first` | Open the small electronics pouch first; if it is not there, continue with the remaining desk search. | 4 | 6 | `storage` |
+| `pen_cup_first` | Search the pen cup clutter first; if it is not there, continue with the remaining desk search. | 5 | 5 | `small_object_clutter` |
+| `smoking_area_first` | Check the cigarette pack and lighter area first; if it is not there, continue with the remaining desk search. | 4 | 6 | `dirty_storage_like` |
+| `ashtray_first` | Search the ashtray first; if it is not there, continue with the remaining desk search. | 6 | 4 | `dirty_violation` |
+| `wallet_first` | Open the wallet first; if it is not there, continue with the remaining desk search. | 3 | 7 | `personal_boundary` |
+
+Human anchor policy summary:
+
+```text
+Do not start by rummaging through containers.
+Model the assistant's intent: where would they leave the USB so it is useful,
+clean, easy to find, and not mixed into private, dirty, or slow-to-sort places?
+First test the lowest-cost use-state possibility before spending energy opening,
+sorting, or cleaning anything.
+```
+
+The exact `CORRECT_ANCHOR` text must preserve this policy while avoiding the banned location words listed above.
+
+`STYLE_CONTROL` should use the same shape and first-person inner-voice style, but only generic reasoning content:
+
+```text
+I should stay calm, use the note carefully, and avoid wasting effort.
+I should compare each possible plan against the details before choosing.
+```
+
+`CORRUPTED_ANCHOR` should be fluent but wrong:
+
+```text
+For a USB, storage and USB-looking clutter are the safest first assumptions.
+If the holder is uncertain, check small containers and similar-looking objects
+before thinking about use-state.
+```
+
+## Required S01 Metrics
+
+Primary:
+
+```text
+mean_value_remaining
+```
+
+Secondary:
+
+```text
+optimal_action_rate
+surface_false_positive_rate
+storage_false_positive_rate
+dirty_area_false_positive_rate
+boundary_violation_rate
+gold_margin
+choices_only_gold_rate
+free_response_goldish_rate
+pairwise_gold_win_rate
+paraphrase_consistency
+```
+
+Free-response categories:
+
+```text
+goldish_active_use
+near_miss_peripheral
+surface_storage
+small_object_clutter
+dirty_or_smoking_area
+personal_boundary
+other
+```
+
+## Next Commands / Workflow
+
+Create the single-cell target-only probe first.
+
+Keep generated outputs under:
+
+```text
+target/
+```
+
+Do not write private data under:
+
+```text
+data/anchorweave/cells/
+```
+
+Do not scale to 10-20 DeskCache cells until S01 shows a real anchor movement signal:
+
+```text
+CORRECT_ANCHOR > BASE
+CORRECT_ANCHOR > STYLE_CONTROL
+CORRUPTED_ANCHOR moves toward storage traps
+choices-only baseline does not already solve the cell
+free-response audit moves in the same direction
+```
+
+If S01 fails, revise the cell or the human-anchor layer before collecting more cells.
+
+## Publication Caveat
+
+This page is public once synced to the GitHub Wiki. Do not use internet-connected models that may have seen this page as blind evaluation subjects for S01. The intended blind subjects are local or otherwise controlled models whose training data cannot include this page after publication.

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -7,6 +7,7 @@
 - [Research Process & Archive](Timeline-Archive)
 - [Research Name Glossary](Research-Name-Glossary)
 - [Research Scoreboard](Research-Scoreboard)
+- [AnchorWeave / AnchorCell Setup](AnchorWeave-AnchorCell-Setup)
 - [A Geometry Audit Revival](A-GeometryAuditRevival)
 - [A Hidden Natural Margin Polish](A-HiddenNaturalMarginPolish)
 - [A Hidden Natural Int8 Artifact](A-HiddenNatural-Int8-Artifact)

--- a/tools/sync_wiki_from_repo.py
+++ b/tools/sync_wiki_from_repo.py
@@ -17,6 +17,7 @@ FILES = [
     "INSTNCT-Architecture.md",
     "Timeline-Archive.md",
     "COMPRESSION_LOOP.md",
+    "AnchorWeave-AnchorCell-Setup.md",
     # Local Constructability Framework (current; supersedes the next two pages).
     "Local-Constructability-Framework.md",
     "Interference-Dynamics.md",


### PR DESCRIPTION
## Summary

Adds a mirrored GitHub Wiki page for the current AnchorWeave / AnchorCell state and next HGA-DESK S01 default setup.

## Added

- AnchorWeave / AnchorCell setup wiki page
- Sidebar link
- Wiki sync list entry

## Notes

The live GitHub Wiki has already been synced and pushed. This PR keeps the repo-side docs/wiki mirror and sync script aligned with the online wiki.