### PR TITLE
docs: consolidate AnchorCell core probe schema

### DIFF
--- a/data/anchorweave/DATASET_CARD.md
+++ b/data/anchorweave/DATASET_CARD.md
@@ -15,7 +15,8 @@ definitions, and not a claim that symbols are grounded by text labels alone.
 
 ## Data Structure
 
-Canonical storage is rich JSONL. Each line is one AnchorCell with:
+Current canonical storage is rich `AnchorWeave-v1.0` JSONL. Each line is one
+AnchorCell with:
 
 - episode
 - relational graph
@@ -29,8 +30,37 @@ Canonical storage is rich JSONL. Each line is one AnchorCell with:
 - human grounding annotation
 - outcome follow-up
 
-Derived SFT, DPO, reward, eval, and graph views are generated from canonical
-cells.
+The locked conceptual standard for future work is:
+
+```text
+AnchorCellCore
+  Situation
+  ImplicitJob
+  RelationalModel
+  SalienceMap
+  Actions
+  Outcomes
+  MemoryHooks
+  HumanSourceTrace optional/private
+  DistilledPolicy
+  CounterfactualChecks
+  SymbolAttachReject
+  ClaimBoundary
+  WorldTruth private/eval-hidden
+
+ProbeSpec derived
+  PromptArms
+  CandidateActions
+  ChoiceOrderSeeds
+  FreeResponseTaxonomy
+  PairwiseTrapProbes
+  ParaphraseVariants
+  ScoringSpec
+  PassCriteria
+```
+
+Derived SFT, DPO, reward, eval, graph, and ProbeSpec views are generated from
+canonical cells.
 
 ## Privacy Boundary
 
@@ -64,6 +94,8 @@ symbol-grounding research via relational episodic anchors.
 - Private data leakage if raw daily annotations are committed.
 - Overgeneralization from a single episode to a broad symbol.
 - Surface-pattern shortcut learning if salience and counterfactuals are weak.
+- Measurement artifacts if ProbeSpec candidates, order seeds, or scoring are
+  mistaken for canonical cell truth.
 - Unsupported inner-state claims if the boundary field is ignored.
 - Premature symbol attachment before stable abstractions are available.
 
@@ -71,6 +103,7 @@ symbol-grounding research via relational episodic anchors.
 
 Current schema: `AnchorWeave-v1.0`
 
+`Core + ProbeSpec` is the locked conceptual standard, not a storage migration.
 Schema changes should create a new schema file, update the dataset card, and
-include migration notes. Existing JSONL cells should remain append-only unless a
-new revision is appended with explicit provenance.
+include migration or exporter notes. Existing JSONL cells should remain
+append-only unless a new revision is appended with explicit provenance.

--- a/data/anchorweave/README.md
+++ b/data/anchorweave/README.md
@@ -6,8 +6,21 @@ available actions, predicted and actual outcomes, counterfactuals, memory hooks,
 pre-symbol abstraction, symbol attach/reject decisions, human grounding
 annotation, and outcome follow-up.
 
-The canonical storage format is append-only JSONL. Derived SFT, DPO, reward,
-eval, and graph views are generated later from the canonical cells.
+The current storage format is append-only `AnchorWeave-v1.0` JSONL. The locked
+conceptual standard for new work is:
+
+```text
+AnchorCell = Core + derived ProbeSpec
+```
+
+Core contains the situation, implicit job, relational/salience structure,
+actions, outcomes, memory hooks, optional/private human source trace, distilled
+policy, counterfactual checks, late symbol attach/reject, claim boundary, and
+hidden world truth. ProbeSpec contains prompt arms, candidate actions, order
+seeds, taxonomies, pairwise probes, paraphrases, scoring, and pass criteria.
+
+Derived SFT, DPO, reward, eval, graph, and ProbeSpec views are generated later
+from canonical cells. They must not become the source of truth.
 
 ## Privacy Boundary
 

--- a/docs/research/ANCHORWEAVE_COLLECTION_PROTOCOL.md
+++ b/docs/research/ANCHORWEAVE_COLLECTION_PROTOCOL.md
@@ -5,18 +5,23 @@
 Collect compact human grounding annotations and convert them into canonical
 AnchorCells without treating symbols as directly grounded labels.
 
+The current storage target is `AnchorWeave-v1.0`. The locked conceptual target is
+`AnchorCellCore + ProbeSpec`; use it as the authoring language until a v2 schema
+or deterministic v1 exporter is approved.
+
 ## Assistant Presentation
 
 For each candidate episode, the assistant presents:
 
 ```text
 SCENE
+IMPLICIT JOB
 RELATIONAL BEADS
 WHAT MATTERS: high / medium / low
 ACTIONS
 OUTCOMES
+MEMORY HOOKS
 COUNTERFACTUALS
-MEMORY HOOK
 ANCHOR
 SYMBOL ATTACH
 SYMBOL REJECT
@@ -31,6 +36,7 @@ The human returns a compact annotation:
 ```text
 GROUNDING_JUDGMENT: valid_anchor | weak_anchor | invalid_anchor | ambiguous_anchor
 BEST_SUMMARY: <one or two sentences>
+IMPLICIT_JOB: <what the situation is really asking the agent to do>
 HIGH: <what matters most>
 MEDIUM: <useful context>
 LOW: <tempting but weak or wrong cue>
@@ -38,7 +44,8 @@ ACTIONS: <available and taken actions>
 OUTCOMES: <predicted and actual outcomes>
 COUNTERFACTUALS: <what would change the interpretation>
 MEMORY_HOOK: <compact retrieval cue>
-ANCHOR: <pre-symbol anchor statement>
+HUMAN_SOURCE_TRACE: <optional/private rugged decision trace, not model-facing>
+DISTILLED_POLICY: <leak-safe reusable policy>
 SYMBOL_ATTACH: <symbols that are supported>
 SYMBOL_REJECT: <symbols that should not attach>
 BOUNDARY: <explicit non-claim>
@@ -52,18 +59,22 @@ FOLLOWUP: <needed or complete>
 1. Normalize the human annotation into `AnchorWeave-v1.0`.
 2. Preserve the episode first, then graph relations, then salience.
 3. Bind actions to predicted and actual outcomes.
-4. Add counterfactuals before symbol decisions.
-5. Add memory hooks as retrieval cues, not as causal rules.
-6. Write the pre-symbol abstraction.
+4. Preserve memory hooks as retrieval cues, not causal rules.
+5. Add counterfactuals before symbol decisions.
+6. Write the implicit job, distilled policy, and claim boundary.
 7. Attach supported symbols late.
 8. Reject tempting unsupported symbols explicitly.
-9. Record the claim boundary.
+9. Keep ProbeSpec candidates, order seeds, and scoring outside canonical truth.
 10. Validate locally before appending.
 
 ## Quality Checks
 
 - Is the symbol attached only after episode, graph, salience, action/outcome,
   and counterfactual support?
+- Do actions, outcomes, and memory hooks remain in the core rather than only in
+  the evaluation apparatus?
+- Is any raw `HumanSourceTrace` private/source material rather than polished
+  rationale or model-facing chain-of-thought?
 - Does the cell reject at least one plausible but unsupported overreach when
   useful?
 - Is private data either absent or kept in ignored local paths?

--- a/docs/research/ANCHORWEAVE_DATASET_SPEC.md
+++ b/docs/research/ANCHORWEAVE_DATASET_SPEC.md
@@ -15,19 +15,57 @@ stable should a symbol be attached or rejected.
 ## Transformation
 
 ```text
-episode
-  -> relational graph
-  -> salience
-  -> action/outcome
-  -> counterfactuals
-  -> memory hook
-  -> pre-symbol abstraction
-  -> symbol attach/reject
+Situation
+  -> ImplicitJob
+  -> RelationalModel / SalienceMap
+  -> Actions / Outcomes / MemoryHooks
+  -> DistilledPolicy
+  -> CounterfactualChecks
+  -> SymbolAttachReject
 ```
+
+## Locked Conceptual Standard
+
+The locked conceptual standard is `AnchorCellCore + ProbeSpec`.
+
+```text
+AnchorCellCore
+  Meta
+  Situation
+  ImplicitJob
+  RelationalModel
+  SalienceMap
+  Actions
+  Outcomes
+  MemoryHooks
+  HumanSourceTrace optional/private
+  DistilledPolicy
+  CounterfactualChecks
+  SymbolAttachReject
+  ClaimBoundary
+  WorldTruth private/eval-hidden
+
+ProbeSpec derived
+  PromptArms
+  CandidateActions
+  ChoiceOrderSeeds
+  FreeResponseTaxonomy
+  PairwiseTrapProbes
+  ParaphraseVariants
+  ScoringSpec
+  PassCriteria
+```
+
+`ProbeSpec` is derived measurement infrastructure. It must not become canonical
+cell truth. High-connectivity decision terrain spans `RelationalModel`,
+`SalienceMap`, `Actions`, `Outcomes`, `MemoryHooks`, and optional/private
+`HumanSourceTrace`.
 
 ## Canonical Unit: AnchorCell
 
-An AnchorCell is one append-only JSON object. The required top-level fields are:
+Current append-only storage uses `AnchorWeave-v1.0`. The v1 schema remains valid
+until a separate v2 schema or deterministic v1 exporter is approved. The required
+v1 top-level fields are:
 
 - `schema_version`
 - `cell_id`
@@ -51,12 +89,11 @@ An AnchorCell is one append-only JSON object. The required top-level fields are:
 `provenance` records source, author, privacy tier, collection method, and whether
 the cell contains private data.
 
-`episode` records the concrete memory-like situation. It should be specific
-enough to preserve the scene but sanitized before public release.
+`episode` records the concrete memory-like situation. In the conceptual standard
+this maps to `Situation`.
 
 `relational_graph` records nodes and edges that make the episode usable as a
-grounding anchor. The graph should distinguish causal, spatial, temporal,
-affordance, comparison, and evidence relations when possible.
+grounding anchor. In the conceptual standard this maps to `RelationalModel`.
 
 `salience` marks what matters at high, medium, and low levels. Low salience is
 not useless; it often captures tempting but wrong cues.
@@ -73,13 +110,15 @@ counterfactuals should block strong symbol attachment.
 without turning incidental context into the rule.
 
 `abstraction` stores the pre-symbol statement, abstraction level, claim boundary,
-and explicit non-claims.
+and explicit non-claims. In the conceptual standard this includes
+`ImplicitJob`, `DistilledPolicy`, and `ClaimBoundary`.
 
-`symbol_binding` records late attach/reject decisions. A rejected symbol is as
-important as an attached symbol because it protects the claim boundary.
+`symbol_binding` records late attach/reject decisions. In the conceptual standard
+this maps to `SymbolAttachReject`.
 
 `human_annotation` records the grounding judgment, confidence, best summary,
-positive tags, error tags, and boundary notes.
+positive tags, error tags, and boundary notes. Optional raw human traces belong
+in private notes or future `HumanSourceTrace`, not in public model-facing text.
 
 `outcome_followup` records later observations, status, and whether follow-up is
 still needed.
@@ -105,6 +144,8 @@ Derived views are generated from canonical cells:
 - Eval: future held-out checks for salience, counterfactual, and claim-boundary
   failures.
 - Graph: flattened relational edges for graph analytics.
+- ProbeSpec: prompt arms, candidate actions, order seeds, free-response
+  taxonomies, pairwise probes, paraphrases, scoring, and pass criteria.
 
 Derived views must not become the source of truth. Regenerate them from the
 canonical append-only cells.

--- a/docs/wiki/AnchorWeave-AnchorCell-Setup.md
+++ b/docs/wiki/AnchorWeave-AnchorCell-Setup.md
@@ -46,6 +46,9 @@ AnchorCell
     ImplicitJob
     RelationalModel
     SalienceMap
+    Actions
+    Outcomes
+    MemoryHooks
     HumanSourceTrace optional/private
     DistilledPolicy
     CounterfactualChecks
@@ -69,6 +72,7 @@ Core rules:
 - The explicit event, scene, task text, and any note or letter belong in `Situation`. They are not the anchor.
 - `ImplicitJob` is the latent job extracted from the explicit situation: what the situation is really asking the agent to do.
 - `RelationalModel` and `SalienceMap` preserve the episode structure, constraints, tempting distractors, and what should or should not matter.
+- `Actions`, `Outcomes`, and `MemoryHooks` are core fields. They tie grounding to available behavior, expected effects, observed effects, and future retrieval cues.
 - `HumanSourceTrace` is raw human think-aloud source material. It is optional, private by default, and not canonical truth.
 - `DistilledPolicy` is the cleaned, reusable, leak-safe model-facing policy extracted from the source trace.
 - `CounterfactualChecks` test whether the policy rejects shortcuts and survives plausible changes.
@@ -82,6 +86,16 @@ For new agents, the safest rule is:
 ```text
 Core = what happened, what mattered, what policy was distilled, and what is true.
 ProbeSpec = how we measure whether a model learned or follows that policy.
+```
+
+High-connectivity decision terrain is not stored in one monologue field. It spans `RelationalModel`, `SalienceMap`, `Actions`, `Outcomes`, `MemoryHooks`, and optional/private `HumanSourceTrace`.
+
+Compatibility note:
+
+```text
+AnchorWeave-v1.0 remains the current append-only storage schema.
+Core + ProbeSpec is the locked conceptual standard for HGA-DESK/S01 and future v2 work.
+S01 is a probe manifest until a v2 schema or deterministic v1 exporter exists.
 ```
 
 ## What Was Built
@@ -187,6 +201,16 @@ Situation:
 ImplicitJob:
   low-cost search under assistant-intent constraints
 
+Actions:
+  first-search plans available in the desk search space
+
+Outcomes:
+  expected search energy and value remaining for each first-search plan
+
+MemoryHooks:
+  retrieval cues such as assistant intent, storage-vs-use, private boundary,
+  clutter avoidance, dirty-area avoidance, and low-cost diagnostic action
+
 HumanSourceTrace:
   the user's Hungarian inner-monologue source layer; private/authoring source
 
@@ -201,6 +225,14 @@ ProbeSpec:
   pairwise trap probes, paraphrase variants, scoring, and pass criteria
 ```
 
+DeskCache S01 is a Search-to-Decision Anchor:
+
+```text
+physical search space -> internal decision terrain -> action/outcome
+```
+
+It tests whether a model links possible desk locations to costs, social boundaries, shortcut pressure, assistant intent, and a diagnostic first action.
+
 S01 text placement is locked as:
 
 | Existing text | Locked layer | Treatment |
@@ -211,7 +243,8 @@ S01 text placement is locked as:
 | User's Hungarian inner monologue | `HumanSourceTrace` | Preserve as private authoring source. Do not present it directly as the anchor. |
 | Human anchor policy summary | `DistilledPolicy` | Convert into the leak-safe `CORRECT_ANCHOR`. |
 | `STYLE_CONTROL` and `CORRUPTED_ANCHOR` drafts | `ProbeSpec.PromptArms` | Balance them against `CORRECT_ANCHOR` by length, style, and fluency. |
-| Candidate plans | `ProbeSpec.CandidateActions` | Use for measurement only; they are not canonical cell truth. |
+| First-search action set | `Actions` | Keep the possible first actions in the core action landscape. |
+| Candidate wording / order | `ProbeSpec.CandidateActions` | Use rendered candidate text for measurement only; it is not canonical cell truth. |
 | Costs, values, and trap labels | `ProbeSpec.ScoringSpec` | Eval-facing only. |
 | Keyboard-side USB-port truth | `WorldTruth` | Hidden truth; never leak into `BASE` or `CORRECT_ANCHOR`. |
 | Free-response categories | `ProbeSpec.FreeResponseTaxonomy` | Include `task_frame_drift`. |


### PR DESCRIPTION
## Summary
- consolidate AnchorCell docs around Core + derived ProbeSpec
- restore Actions, Outcomes, and MemoryHooks as explicit Core fields
- clarify that AnchorWeave-v1.0 remains the current storage schema while Core + ProbeSpec is the locked conceptual standard
- mark S01 as a Search-to-Decision Anchor and probe manifest until v2 schema/exporter work

## Validation
- python tools/sync_wiki_from_repo.py --dry-run
- git diff --check