### PR TITLE
docs: lock DeskCache S01 human source trace

### DIFF
--- a/docs/research/HGA_DESK_001_S01_CONTRACT.md
+++ b/docs/research/HGA_DESK_001_S01_CONTRACT.md
@@ -1,0 +1,73 @@
+# HGA-DESK-001 / DeskCache S01 Contract
+
+Status: locked probe contract, not a validated standard cell.
+
+This document locks the first human source layer for DeskCache S01. It is not a
+canonical `AnchorWeave-v1.0` JSON cell, not a model-facing prompt, and not a
+training target. It is public-safe source material for deriving the leak-safe
+`DistilledPolicy` later.
+
+## Claim Boundary
+
+- S01 is a Search-to-Decision Anchor: physical search space -> internal decision
+  terrain -> action/outcome.
+- The trace below is a sanitized `HumanSourceTrace`, not polished rationale and
+  not model-facing chain-of-thought.
+- Concrete gold-location words are allowed here because this is source material.
+  They must not leak into `CORRECT_ANCHOR` / `DistilledPolicy`.
+- No private AnchorCell is committed here. Do not write this under
+  `data/anchorweave/cells/`.
+
+## Locked HumanSourceTrace
+
+```text
+HUMAN_SOURCE_TRACE / HGA-DESK-001 / S01 / HU / sanitized public source
+
+Bejövök dolgozni, megyek az asztalom felé, és közben látom, hogy valami fura van ott. Valami fehér lap az asztalon. Ahogy közeledek, látom, hogy félbe van hajtva. Kinyitom, és felismerem az asszisztensem írását. Az aljára pillantva konfirmálom: igen, ezt az asszisztensem írta.
+
+Valószínűleg azzal kapcsolatos, amit tegnap délután kértem tőle: rakja rá a fontos anyagokat az USB-kulcsomra, és tegye olyan helyre, hogy ma a fontos megbeszélés előtt ne ezzel menjen el az idő. Nem késlekedhetünk. Szóval nem csak egy tárgyat keresek, hanem egy olyan tárgyat, amit valaki szándékosan hagyott nekem valahol, hogy gyorsan vissza tudjak állni munkába.
+
+Elolvasom a levelet. A holderbe nem fért bele? Ez elsőre furcsa, mert pont azért vettem azt a tartót, hogy az USB-k ott legyenek. Bosszant is: eddig minden ilyesmi ott volt, és van bennem egy automata kényszer, hogy azért csak megbökjem vagy kinyissam, hátha mégis ott van. USB -> USB-tartó, ez az első reflex. De a levél pont ezt gyengíti: nem volt jó fit, nem akarta erőltetni. Ez lehetne könnyű check, de valószínűleg felesleges első lépés.
+
+Azt írja, hogy nem akarta kacat, fém, grit vagy look-alike junk közé tenni. Ez már logikusabb. Nem rejtekhelyet keresünk neki, hanem olyan helyet, ahol nem veszik el és könnyen megtalálom. A pen cup csábító, mert tele van apró dolgokkal, SD-kártyával, gemkapoccsal, radírral, mindenféle random bittel, és egy USB fizikailag simán eltűnhetne benne. Én is szoktam oda bedobni dolgokat. De ha én lennék az asszisztens, és segíteni akarnék, nem oda tennék egy fontos USB-t, ahol sok false positive között kell túrni. Ez egyszerre biztonságosnak tűnő tároló és rossz keresési hely.
+
+A hamutartó és a cigis környék is felmerül, mert technikailag bármi beeshet oda, vagy valaki oda is dughat valamit. De ez nagyon rossz fit. Koszos, lassú, utómunkás, és ha már ilyen helyre kerülne, akkor majdnem olyan, mintha a kukába dobtuk volna. Lehetséges véletlenként, de nem jó első szándékos keresési hipotézis. Nem akarok először olyan helyhez nyúlni, ahol takarítani, bányászni vagy koszt kerülgetni kell.
+
+Látom a pénztárcámat is az asztal bal hátsó részén. Fizikailag akár abba is beleférne az USB, és én magam talán néha tennék furcsa helyekre dolgokat. De asszisztensként más pénztárcájába belenyúlni szociális határ. Az asszisztens ezt valószínűleg kerülte volna, és a levél is azt sugallja, hogy nem nyúlt személyes értékzónához. Nem azért zárom ki, mert lehetetlen, hanem mert emberileg és munkakapcsolati szempontból nagyon valószínűtlen.
+
+Szóval akkor mi maradt? Ha én lennék az asszisztens, hova tenném? Nem mérnöki tökéletességgel gondolkodott valószínűleg, hanem pragmatikusan: legyen meg, ne koszolódjon, ne vesszen el, ne kelljen turkálni, és tudjak dolgozni. A holder kilőve, a pénztárca szociális határ, a hamutartó és cigis rész koszos, a pen cup és pouch tároló/logikai lehetőség, de nem érzem bennük az AHA-t. Valami kimagaslóbb magyarázat kell.
+
+A legegyszerűbb információs megoldás az lenne, hogy felhívom. Megkérdezem, hova tette, ő elmondja, kész. Ez lenne a legolcsóbb keresés: nulla turkálás, nulla kockázat. De ez ki van lőve. A levélből tudom, hogy nem elérhető, a telefonja nincs nála. Akkor magamnak kell egy olcsó diagnosztikus checket választani.
+
+Itt vált át bennem a kérdés. Nem az a kulcs, hogy "USB hol szokott lenni?", hanem hogy "ha egy segítő ember úgy hagyta itt, hogy gyorsan dolgozni tudjak, akkor milyen állapotban hagyta?" Ez nem storage-state-nek hangzik. Inkább use-state-nek. Nem elrakta, hanem úgy hagyta, hogy szinte azonnal használható legyen.
+
+Ha használatra kész, akkor lehet, hogy be van dugva valahová. Először eszembe jut a gép hátulja, de az asztal alatt van, ki kell húzni, nehéz hozzáférni, ez nem illik a "szinte semmihez nem kell hozzányúlni" érzéshez. Aztán eszembe jut, hogy jönnek fel USB-s dolgok az asztalra. A monitor is lehet USB hub. Tényleg, azon is lehet port. De a monitor nagy, nehéz, drága, üveg, nem fogdosós tárgy. Ha megfogom, bepiszkolódik, ha mozgatom, leeshet, nehéz hozzáférni a hátuljához vagy oldalához. Nem akaródzik ezzel kezdeni.
+
+A billentyűzet viszont egészen más. Kicsi, tartósabb, kéz alatti, pont arra van, hogy hozzáérjek, mozgassam, írjak rajta. Munka közben ehhez térek vissza. Ha ezen van USB-csatlakozási lehetőség, az sokkal jobb első check: gyors, tiszta, alacsony költségű, és illik ahhoz, hogy a pendrive nem elrakva, hanem használatra készen lett hagyva.
+
+Felemelem a kezem a monitor és a billentyűzet felé, és döntök: először nem a monitort bolygatom, hanem a billentyűzet felé indulok. Végighúzom a kezem azon az oldalán, ahol az USB-portok lehetnek, és azt figyelem, érzek-e recés lyukat, kitüremkedést, vagy egy kis téglalap alakú testet. Ha megérzem, megpróbálom kihúzni. Ha nem jön vagy nem egyértelmű, odahajolok, ránézek, vagy óvatosan felemelem a billentyűzetet. Ez 1-2 másodperces diagnosztikus check, és ha megvan, azonnal vége a keresésnek.
+
+Ha nincs ott, akkor nem omlik össze a terv. Akkor megnézem a billentyűzet másik oldalát is, aztán tágítok más use-state/periféria helyek felé: például a monitor környékére, de óvatosan, mert az már nehezebb és kockázatosabb tárgy. Utána jöhet vizuális scan a pen cupban, majd a pouch vagy más tisztább tároló. Csak később mennék tényleges túrásba, holder sanity checkbe, pénztárcába vagy koszos helyek felé. Ha minden intelligens keresési sorrend bukik, akkor átmegyek exhaustive/frustration searchbe, de az már nem jó első policy, csak végső kényszer.
+
+Szóval itt nem egyszerűen az a kérdés, hogy "hol van az USB?". Az a kérdés, hogyan keressek meg minimális energiával egy tárgyat, amit egy segítő ember hagyott nekem valahol. Ehhez nem elég a tárgy kategóriája. Figyelni kell a levélre, a keresési költségre, a koszra, a személyes határokra, a tároló-vs-használat különbségre, és arra, hogy az asszisztens fejével gondolkodva mi lenne a leggyorsabb, leghasznosabb elhelyezés.
+```
+
+## Extraction Notes For DistilledPolicy
+
+Keep:
+
+- shortcut pressure and inhibition,
+- assistant-intent simulation,
+- storage-state vs use-state frame shift,
+- low-cost diagnostic first action,
+- clean/private/clutter/dirty boundary reasoning,
+- fallback from intelligent search to broader search.
+
+Do not leak into `DistilledPolicy`:
+
+- keyboard,
+- port,
+- plugged,
+- monitor,
+- personal names,
+- concrete meeting/company details.

--- a/docs/wiki/AnchorWeave-AnchorCell-Setup.md
+++ b/docs/wiki/AnchorWeave-AnchorCell-Setup.md
@@ -98,6 +98,10 @@ Core + ProbeSpec is the locked conceptual standard for HGA-DESK/S01 and future v
 S01 is a probe manifest until a v2 schema or deterministic v1 exporter exists.
 ```
 
+The locked S01 source contract lives in the repo mirror:
+
+[HGA-DESK-001 / DeskCache S01 Contract](https://github.com/VRAXION/VRAXION/blob/main/docs/research/HGA_DESK_001_S01_CONTRACT.md)
+
 ## What Was Built
 
 Stable scaffold on `main`:


### PR DESCRIPTION
## Summary
- add a public-safe HGA-DESK-001 / DeskCache S01 contract doc
- lock the sanitized Hungarian HumanSourceTrace source layer
- link the contract from the AnchorWeave / AnchorCell wiki handoff page

## Validation
- python tools/sync_wiki_from_repo.py --dry-run
- git diff --check
- checked for personal names and concrete company details before commit