### PR TITLE
Fix CodeQL script tag scan

### DIFF
--- a/scripts/audit_instnct_static_site.mjs
+++ b/scripts/audit_instnct_static_site.mjs
@@ -660,7 +660,7 @@ for (const [name, expected] of [
 }
 if (!anchorcellCspDirectives.has("upgrade-insecure-requests")) fail("AnchorCell CSP missing upgrade-insecure-requests");
 
-const jsonLdMatch = html.match(/<script\s+type="application\/ld\+json">([\s\S]*?)<\/script\s*>/i);
+const jsonLdMatch = html.match(/<script\s+type="application\/ld\+json">([\s\S]*?)<\/script\b[^>]*>/i);
 if (!jsonLdMatch) {
   fail("missing JSON-LD script");
 } else {
@@ -681,7 +681,7 @@ if (!jsonLdMatch) {
   }
 }
 
-for (const scriptTag of html.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script\s*>/gi)) {
+for (const scriptTag of html.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script\b[^>]*>/gi)) {
   const tag = scriptTag[0];
   const type = attr(tag, "type");
   const src = attr(tag, "src");
@@ -692,7 +692,7 @@ for (const scriptTag of html.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script\s*>/
     fail(`external script source is not allowed: ${src}`);
   }
 }
-for (const scriptTag of anchorcell.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script\s*>/gi)) {
+for (const scriptTag of anchorcell.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script\b[^>]*>/gi)) {
   const tag = scriptTag[0];
   const type = attr(tag, "type");
   const src = attr(tag, "src");


### PR DESCRIPTION
## Summary
- Accept script end tags with attributes/whitespace in the public static-site audit regexes.
- Keeps the AnchorCell/public-site audit behavior but avoids CodeQL js/bad-tag-filter alerts.

## Verification
- node --check scripts/audit_instnct_static_site.mjs
- node scripts/audit_instnct_static_site.mjs
- python scripts/audit_public_surface.py
- powershell -ExecutionPolicy Bypass -File scripts/check_public_export.ps1