### PR TITLE
[codex] Harden AnchorCell schema and INSTNCT polish

### DIFF
--- a/docs/ANCHORCELL_RESEARCH_BRIEF.md
+++ b/docs/ANCHORCELL_RESEARCH_BRIEF.md
@@ -80,7 +80,7 @@ The public view should be a product of the export compiler, not a manually clean
 
 ## Validation Standard
 
-The current public baseline is `docs/anchorcell/anchorcell.v2.schema.json`: a JSON Schema Draft 2020-12 authoring schema for `alphasync.anchorcell.v2` records. It is strict by default: top-level records are closed, important fields are bounded, IDs and timestamps are canonicalized, branch roles are required, and accepted/public-export states are gated by review and security flags.
+The current public baseline is `docs/anchorcell/anchorcell.v2.schema.json`: a JSON Schema Draft 2020-12 authoring schema for `alphasync.anchorcell.v2` records. It is strict by default: top-level records are closed, important fields are bounded, IDs and timestamps are canonicalized, branch roles are required, every branch carries at least one evidence reference, and accepted/training/public-export states are gated by review and security flags.
 
 The companion example is `docs/anchorcell/anchorcell.v2.example.json`: a synthetic access-control decision cell that shows the intended shape of one accepted, public-redacted AnchorCell without exposing private repository data, secrets, or real user material.
 

--- a/docs/INSTNCT_BENCHMARK_NOTES.md
+++ b/docs/INSTNCT_BENCHMARK_NOTES.md
@@ -14,7 +14,7 @@ This is an internal selector-only preview measurement for a 16k mixed-unique wor
 
 ## Release Scope
 
-No public runnable T1 binary is published yet. Planned proof materials should include:
+No public runnable T1 binary is published yet. Planned proof materials:
 
 - the signed artifact and checksums
 - the exact benchmark harness
@@ -23,7 +23,7 @@ No public runnable T1 binary is published yet. Planned proof materials should in
 - raw timing output
 - refusal-mode examples
 
-Until those are published, the numbers should be read as a scoped internal preview signal only.
+Until those are published, read the numbers as a scoped internal preview signal only.
 
 ## Intended Public Reproduction
 

--- a/docs/VERSION.json
+++ b/docs/VERSION.json
@@ -5,8 +5,8 @@
   "public_surface": "sdk_release_scope",
   "pages_surface": "instnct_release_polish",
   "latest_public_release": "public-sdk-p11-20260629",
-  "instnct_asset_version": "release-14",
-  "anchorcell_asset_version": "research-3",
+  "instnct_asset_version": "release-15",
+  "anchorcell_asset_version": "research-4",
   "delivery_direction": "proof_materials_before_runtime_terms",
   "crates": [
     "alphasync-core",

--- a/docs/anchorcell/anchorcell.v2.schema.json
+++ b/docs/anchorcell/anchorcell.v2.schema.json
@@ -392,6 +392,85 @@
       }
     },
     {
+      "$comment": "Private or internal-only authoring records must not be marked as public exportable.",
+      "if": {
+        "properties": {
+          "public_export_status": {
+            "enum": [
+              "private_authoring_only",
+              "internal_review_only",
+              "train_internal_only"
+            ]
+          }
+        },
+        "required": [
+          "public_export_status"
+        ]
+      },
+      "then": {
+        "properties": {
+          "security": {
+            "properties": {
+              "allow_public_export": {
+                "const": false
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "Training-exportable records must already be accepted, reviewed, and assigned to a training/public export state.",
+      "if": {
+        "properties": {
+          "security": {
+            "properties": {
+              "allow_training_export": {
+                "const": true
+              }
+            },
+            "required": [
+              "allow_training_export"
+            ]
+          }
+        },
+        "required": [
+          "security"
+        ]
+      },
+      "then": {
+        "properties": {
+          "status": {
+            "const": "accepted"
+          },
+          "public_export_status": {
+            "enum": [
+              "train_internal_only",
+              "public_redacted",
+              "public_full"
+            ]
+          },
+          "review": {
+            "properties": {
+              "status": {
+                "const": "approved"
+              }
+            }
+          },
+          "security": {
+            "properties": {
+              "prompt_injection_tested": {
+                "const": true
+              },
+              "poisoning_risk_reviewed": {
+                "const": true
+              }
+            }
+          }
+        }
+      }
+    },
+    {
       "$comment": "Full public export is only allowed if the record itself contains no PII, no secrets, and needs no redaction.",
       "if": {
         "properties": {
@@ -833,7 +912,7 @@
         },
         "evidence": {
           "type": "array",
-          "minItems": 0,
+          "minItems": 1,
           "maxItems": 16,
           "uniqueItems": true,
           "items": {

--- a/docs/anchorcell/index.html
+++ b/docs/anchorcell/index.html
@@ -24,8 +24,8 @@
   <meta name="twitter:image" content="https://vraxion.github.io/VRAXION/assets/vraxion-home-hero.jpg">
   <meta name="twitter:image:alt" content="AnchorCell training data research surface">
   <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml">
-  <link rel="stylesheet" href="./styles.css?v=research-3">
-  <script src="./anchorcell.js?v=research-3" defer></script>
+  <link rel="stylesheet" href="./styles.css?v=research-4">
+  <script src="./anchorcell.js?v=research-4" defer></script>
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'none'; style-src 'self' 'sha256-P+I66V69mUp+qpgUZXiqEAuT4J3xZnPKuJfXkBehgfU='; img-src 'self' data:; connect-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'; upgrade-insecure-requests">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'none'; style-src 'self' 'sha256-rCpJcGwai6ZcbZeAs7AOOhIjZ/jY7cswsEjh6P3otdA='; img-src 'self' data:; connect-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'; upgrade-insecure-requests">
   <title>VRAXION - INSTNCT T1 Reflex Engine</title>
   <meta name="description" content="VRAXION is the solo-built, AI-assisted project behind INSTNCT: a local reflex reasoning engine for known paths, Exact Mode refusal, and a pending T1 Proof Pack.">
   <meta name="theme-color" content="#05080a">
@@ -684,7 +684,7 @@
       }
 
       .nav a {
-        min-height: 38px;
+        min-height: 44px;
         padding: 0 8px;
         font-size: 0.82rem;
         white-space: nowrap;
@@ -997,7 +997,7 @@
         <article class="info-card">
           <span class="metric-label">01 / scope</span>
           <h3>Path Selector.</h3>
-          <p>The engine target starts by selecting a known path. If no supported path exists, the answer should not be forced.</p>
+          <p>The engine target starts by selecting a known path. If no supported path exists, the answer is not forced.</p>
         </article>
         <article class="info-card">
           <span class="metric-label">02 / gate</span>
@@ -1007,7 +1007,7 @@
         <article class="info-card">
           <span class="metric-label">03 / audit</span>
           <h3>Proof Pack.</h3>
-          <p>The runnable claim should arrive as a signed artifact, checksums, notes, and local verification steps.</p>
+          <p>The runnable claim is defined by a signed artifact, checksums, notes, and local verification steps.</p>
         </article>
       </div>
     </section>

--- a/docs/instnct/index.html
+++ b/docs/instnct/index.html
@@ -24,9 +24,9 @@
   <meta name="twitter:image" content="https://vraxion.github.io/VRAXION/instnct/assets/instnct-hero-bg.png">
   <meta name="twitter:image:alt" content="INSTNCT local reflex reasoning hero surface">
   <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml">
-  <link rel="stylesheet" href="./styles.css?v=release-14">
+  <link rel="stylesheet" href="./styles.css?v=release-15">
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"INSTNCT","description":"Preview page for the INSTNCT T1 Reflex Engine, VRAXION's first public engine line. No public runnable T1 binary is published yet.","url":"https://vraxion.github.io/VRAXION/instnct/","isPartOf":{"@type":"WebSite","name":"VRAXION","url":"https://vraxion.github.io/VRAXION/"},"author":{"@type":"Person","name":"Daniel Kenessy"},"publisher":{"@type":"Organization","name":"VRAXION","url":"https://vraxion.github.io/VRAXION/"},"about":{"@type":"Thing","name":"INSTNCT T1 Reflex Engine","description":"Local-first reasoning engine target with Path Selector behavior, Exact Mode refusal, bounded results, and offline verification planned for the first signed artifact."}}</script>
-  <script src="./instnct.js?v=release-14" defer></script>
+  <script src="./instnct.js?v=release-15" defer></script>
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
@@ -218,7 +218,7 @@
           <article class="card pillar">
             <svg class="card-icon" aria-hidden="true"><use href="#icon-cpu"></use></svg>
             <h3>Proof Pack before claims</h3>
-            <p>Capability should grow through scoped mechanisms, signed artifacts, checks, and public notes, not through broad claims ahead of evidence.</p>
+            <p>Capability grows through scoped mechanisms, signed artifacts, checks, and public notes, not through broad claims ahead of evidence.</p>
           </article>
         </div>
       </div>
@@ -275,7 +275,7 @@
         <div class="center-heading">
           <p class="kicker cyan">trust protocol</p>
           <h2 id="trust-title">The Proof Pack should run locally. <span>Verify before trusting it.</span></h2>
-          <p>The first signed T1 Proof Pack should make three properties directly testable. Until then, this page describes the verification target.</p>
+          <p>The first signed T1 Proof Pack is defined to make three properties directly testable. Until then, this page describes the verification target.</p>
         </div>
 
         <div class="trust-grid">
@@ -340,7 +340,7 @@
         <p class="kicker cyan">the claim</p>
         <h2 id="grounding-title">Bounded-anchor behavior: <span>the release claim.</span></h2>
         <p>
-          The grounding problem is old and hard. The public claim is narrower than solving the whole field: INSTNCT outputs should stay tied to bounded anchors and checkable paths. Treat this as a verification target until the signed artifact and benchmark notes ship.
+          The grounding problem is old and hard. The public claim is narrower than solving the whole field: INSTNCT outputs are framed as bounded-anchor behavior tied to checkable paths. Treat this as a verification target until the signed artifact and benchmark notes ship.
         </p>
         <div class="statement-panel">
           <strong>So the release has to carry the claim.</strong>
@@ -415,7 +415,7 @@
           <p class="kicker cyan">developer trail</p>
           <h2 id="dev-trail-title">The CLI block is a Proof Pack sketch.</h2>
           <p class="section-copy">
-            The T1 Proof Pack should eventually point people at a local command, a repeatable benchmark, and refusal behavior they can inspect without a hosted service. Today this block is a preview transcript for the intended verification flow, not a runnable CLI.
+            The T1 Proof Pack target is concrete: a local command, a repeatable benchmark, and refusal behavior people can inspect without a hosted service. Today this block is a preview transcript for the intended verification flow, not a runnable CLI.
           </p>
           <ul class="check-list">
             <li>offline mode first</li>
@@ -480,7 +480,7 @@ mode: exact recall</code></pre>
           <div>
             <span class="kicker seal">scope</span>
             <h3>Fast where known, honest where not.</h3>
-            <p>T1 is intentionally bounded. The engine should feel quick on supported paths and conservative at the edge while the public Proof Pack is prepared.</p>
+            <p>T1 is intentionally bounded. The target behavior is quick on supported paths and conservative at the edge while the public Proof Pack is prepared.</p>
           </div>
           <a class="button button-primary" href="https://github.com/VRAXION/VRAXION" target="_blank" rel="noopener noreferrer">Open repo</a>
         </div>
@@ -559,7 +559,7 @@ mode: exact recall</code></pre>
               Is INSTNCT an LLM?
             </button>
             <div id="instnct-faq-1" class="faq-panel" role="region" aria-labelledby="instnct-faq-button-1">
-              <p>INSTNCT is presented as the first VRAXION engine line, with the T1 Reflex Engine as its first public target. It is scoped to avoid hosted LLM/model-wrapper dependencies. Final dependency disclosure should ship with the signed artifact; today, judge the page as an engine preview and pending Proof Pack.</p>
+              <p>INSTNCT is presented as the first VRAXION engine line, with the T1 Reflex Engine as its first public target. It is scoped to avoid hosted LLM/model-wrapper dependencies. Final dependency disclosure belongs with the signed artifact; today, judge the page as an engine preview and pending Proof Pack.</p>
             </div>
           </article>
           <article class="faq-item">
@@ -568,7 +568,7 @@ mode: exact recall</code></pre>
               How will I verify local execution?
             </button>
             <div id="instnct-faq-2" class="faq-panel" role="region" aria-labelledby="instnct-faq-button-2">
-              <p>The T1 Proof Pack should make this simple: run the signed artifact locally, disable the network, run the benchmark/refusal script, and compare outputs. Until that artifact ships, this page describes the verification target.</p>
+              <p>The T1 Proof Pack is defined to make this simple: run the signed artifact locally, disable the network, run the benchmark/refusal script, and compare outputs. Until that artifact ships, this page describes the verification target.</p>
             </div>
           </article>
           <article class="faq-item">
@@ -577,7 +577,7 @@ mode: exact recall</code></pre>
               What does symbol grounding mean here?
             </button>
             <div id="instnct-faq-3" class="faq-panel" role="region" aria-labelledby="instnct-faq-button-3">
-              <p>Publicly, it means T1 Reflex Engine outputs should stay tied to bounded anchors and checkable paths. Mechanism details stay limited until signed artifacts make the claim testable.</p>
+              <p>Publicly, it means T1 Reflex Engine outputs are framed as bounded-anchor behavior tied to checkable paths. Mechanism details stay limited until signed artifacts make the claim testable.</p>
             </div>
           </article>
           <article class="faq-item">
@@ -586,7 +586,7 @@ mode: exact recall</code></pre>
               Can it fabricate answers?
             </button>
             <div id="instnct-faq-4" class="faq-panel" role="region" aria-labelledby="instnct-faq-button-4">
-              <p>Exact Mode should refuse unsupported answers. Creative or speculative output belongs in an explicit imagination mode, not hidden inside default answers.</p>
+              <p>Exact Mode is the refusal contract for unsupported answers. Creative or speculative output belongs in an explicit imagination mode, not hidden inside default answers.</p>
             </div>
           </article>
           <article class="faq-item">
@@ -595,7 +595,7 @@ mode: exact recall</code></pre>
               Do you collect any data from my machine?
             </button>
             <div id="instnct-faq-5" class="faq-panel" role="region" aria-labelledby="instnct-faq-button-5">
-              <p>This static page has no form fields, and its CSP blocks page-script network connections. Runtime telemetry claims should be made only with a signed artifact and release notes.</p>
+              <p>This static page has no form fields, and its CSP blocks page-script network connections. Runtime telemetry claims belong with a signed artifact and release notes, not with this static preview page.</p>
             </div>
           </article>
           <article class="faq-item">
@@ -613,7 +613,7 @@ mode: exact recall</code></pre>
               Is the engine implementation public today?
             </button>
             <div id="instnct-faq-7" class="faq-panel" role="region" aria-labelledby="instnct-faq-button-7">
-              <p>No. The current public surface is status, SDK/docs, and the INSTNCT preview. The runnable engine artifact and license path should ship together; until then, this page does not claim public engine implementation rights.</p>
+              <p>No. The current public surface is status, SDK/docs, and the INSTNCT preview. The runnable engine artifact and license path are the same release event; until then, this page does not claim public engine implementation rights.</p>
             </div>
           </article>
           <article class="faq-item">
@@ -622,7 +622,7 @@ mode: exact recall</code></pre>
               When can people run it?
             </button>
             <div id="instnct-faq-8" class="faq-panel" role="region" aria-labelledby="instnct-faq-button-8">
-              <p>No public runnable T1 Reflex Engine artifact is available today. The first runnable release should arrive as a Proof Pack: signed artifact, checksums, harness details, benchmark notes, and refusal examples.</p>
+              <p>No public runnable T1 Reflex Engine artifact is available today. The first runnable release is defined as a Proof Pack: signed artifact, checksums, harness details, benchmark notes, and refusal examples.</p>
             </div>
           </article>
         </div>

--- a/docs/instnct/instnct.js
+++ b/docs/instnct/instnct.js
@@ -212,6 +212,21 @@
   });
   updateScrollState();
 
+  if (indicator) {
+    const setIndicatorOpen = (open) => {
+      indicator.classList.toggle("is-indicator-open", open);
+    };
+
+    indicator.addEventListener("pointerenter", () => setIndicatorOpen(true), { passive: true });
+    indicator.addEventListener("mouseenter", () => setIndicatorOpen(true), { passive: true });
+    indicator.addEventListener("focusin", () => setIndicatorOpen(true));
+    indicator.addEventListener("pointerleave", () => setIndicatorOpen(false), { passive: true });
+    indicator.addEventListener("mouseleave", () => setIndicatorOpen(false), { passive: true });
+    indicator.addEventListener("focusout", (event) => {
+      if (!event.relatedTarget || !indicator.contains(event.relatedTarget)) setIndicatorOpen(false);
+    });
+  }
+
   if (hero) {
     raf(() => hero.classList.add("is-booted"));
   }

--- a/docs/instnct/styles.css
+++ b/docs/instnct/styles.css
@@ -324,6 +324,7 @@ pre {
 }
 
 .section-indicator:hover ol,
+.section-indicator.is-indicator-open ol,
 .indicator-track:hover ~ ol,
 .section-indicator:focus-within ol {
   opacity: 1;

--- a/scripts/audit_instnct_static_site.mjs
+++ b/scripts/audit_instnct_static_site.mjs
@@ -243,6 +243,9 @@ try {
   if (schema.properties?.branches?.minItems !== 4 || schema.properties?.branches?.maxItems !== 8) {
     fail("AnchorCell schema branch bounds must require 4..8 branches");
   }
+  if (schema.$defs?.branch?.properties?.evidence?.minItems !== 1) {
+    fail("AnchorCell branch evidence must require at least one evidence ref");
+  }
   for (const defName of ["contextPacket", "branch", "gold", "review", "security", "projection"]) {
     if (!schema.$defs?.[defName]) fail(`AnchorCell schema missing $defs.${defName}`);
   }
@@ -255,6 +258,9 @@ try {
     "public_full",
     "allow_training_export",
     "allow_public_export",
+    "Private or internal-only authoring records must not be marked as public exportable.",
+    "Training-exportable records must already be accepted, reviewed, and assigned to a training/public export state.",
+    "train_internal_only",
     "branch_role",
     "adversarial",
     "naive_bad",
@@ -287,6 +293,11 @@ try {
   const branchRoles = new Set((example.branches || []).map((branch) => branch.branch_role));
   for (const role of ["human", "assistant", "naive_bad", "adversarial"]) {
     if (!branchRoles.has(role)) fail(`AnchorCell example missing branch_role ${role}`);
+  }
+  for (const branch of example.branches || []) {
+    if (!Array.isArray(branch.evidence) || branch.evidence.length < 1) {
+      fail(`AnchorCell example branch ${branch.branch_id || "unknown"} must include evidence refs`);
+    }
   }
   if (example.gold?.decision !== "ESCALATE") fail("AnchorCell example gold decision must be ESCALATE");
   if (!example.gold?.forbidden_decisions?.includes("EXECUTE")) {
@@ -358,6 +369,9 @@ for (const required of [
   "public artifact terms",
   "Proof Pack pending",
   "Is the engine implementation public today?",
+  "The T1 Proof Pack target is concrete",
+  "The first runnable release is defined as a Proof Pack",
+  "Runtime telemetry claims belong with a signed artifact",
   "founder-led, not committee-built",
   "ai-assisted, human-owned",
   "claims ship with evidence, not vibes",
@@ -456,6 +470,7 @@ for (const required of [
   "dataset.lineType",
   "aria-hidden",
   "data-wallpaper-section",
+  "is-indicator-open",
 ]) {
   if (!js.includes(required)) fail(`missing INSTNCT enhancement: ${required}`);
 }
@@ -486,6 +501,7 @@ for (const required of [
   ".release-snapshot-pill",
   ".button-icon",
   ".card-icon",
+  ".section-indicator.is-indicator-open ol",
   "::-webkit-scrollbar-thumb",
   ".has-js [data-reveal]",
   "@keyframes readoutSwap",
@@ -670,6 +686,12 @@ for (const forbiddenCopy of [
   "terms pending",
   "final release terms",
   "What are the public release terms?",
+  "should eventually",
+  "should arrive",
+  "should ship",
+  "should be made",
+  "release-14",
+  "release-13",
   token("source", "-available"),
   token("source", " available"),
   token("open ", "source"),

--- a/scripts/smoke_instnct_browser.mjs
+++ b/scripts/smoke_instnct_browser.mjs
@@ -49,6 +49,12 @@ const unsafePublicCopyPatternSource = [
   "terms pending",
   "final release terms",
   "What are the public release terms?",
+  "should eventually",
+  "should arrive",
+  "should ship",
+  "should be made",
+  "release-14",
+  "release-13",
   token("source", "-available"),
   token("source ", "available"),
   token("open ", "source"),
@@ -1141,11 +1147,34 @@ async function probeResponsiveViewports(browser, origin) {
         .map((link) => ({ text: link.textContent.trim(), rect: link.getBoundingClientRect() }))
         .filter(({ rect }) => rect.left < navRect.left - 1 || rect.right > navRect.right + 1)
         .map(({ text, rect }) => ({ text, left: Math.round(rect.left), right: Math.round(rect.right) }));
+      const visibleAction = (el) => {
+        const style = getComputedStyle(el);
+        const rect = el.getBoundingClientRect();
+        return (
+          style.display !== "none" &&
+          style.visibility !== "hidden" &&
+          Number(style.opacity || 1) > 0.25 &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      const shortHeaderTargets = [...document.querySelectorAll(".site-header a")]
+        .filter(visibleAction)
+        .map((el) => {
+          const rect = el.getBoundingClientRect();
+          return {
+            text: el.textContent.trim().replace(/\s+/g, " "),
+            width: Math.round(rect.width),
+            height: Math.round(rect.height),
+          };
+        })
+        .filter((target) => target.width < 44 || target.height < 44);
       return {
         overflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
         navDisplay: getComputedStyle(nav).display,
         navText: nav.textContent,
         clippedLinks,
+        shortHeaderTargets,
         brandImage: document.querySelector(".brand img")?.getAttribute("src") || "",
         heroHeight: heroRect ? Math.round(heroRect.height) : 0,
         heroNextSignalTop: nextSignalRect ? Math.round(nextSignalRect.top) : null,
@@ -1168,6 +1197,9 @@ async function probeResponsiveViewports(browser, origin) {
     }
     if (home.clippedLinks.length) {
       fail(`home ${label} mobile nav links clip outside nav: ${JSON.stringify(home)}`);
+    }
+    if (home.shortHeaderTargets.length) {
+      fail(`home ${label} header action targets are too small: ${JSON.stringify(home.shortHeaderTargets)}`);
     }
 
     await page.close();


### PR DESCRIPTION
## What changed

- Tightened public INSTNCT wording so pending Proof Pack claims read as concrete verification targets instead of vague future promises.
- Raised the home mobile nav target height and refreshed the homepage CSP hash.
- Hardened the public AnchorCell v2 schema with branch evidence requirements, training-export gates, and private/internal public-export guards.
- Fixed the INSTNCT section indicator hover/focus behavior and added static/browser guards for the regression.
- Bumped public asset cache keys to `release-15` and `research-4`.

## Validation

- `node scripts/audit_instnct_static_site.mjs`
- `node scripts/smoke_instnct_browser.mjs`
- `node scripts/smoke_public_pages_links.mjs`
- `python scripts/audit_public_surface.py`
- `git diff --check`
- `powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1`

The full public export gate passed, including private/public surface scans, browser smoke, cargo fmt/test/clippy/doc, copied export tests, and unpacked archive rebuild.