### PR TITLE
[codex] Refresh public version date

### DIFF
--- a/docs/VERSION.json
+++ b/docs/VERSION.json
@@ -1,7 +1,7 @@
 {
   "schema": "vraxion.public.version.v1",
   "status": "p11_public_delivery_scope",
-  "date": "2026-07-04",
+  "date": "2026-07-05",
   "public_surface": "sdk_release_scope",
   "pages_surface": "instnct_release_polish",
   "latest_public_release": "public-sdk-p11-20260629",

--- a/scripts/audit_instnct_static_site.mjs
+++ b/scripts/audit_instnct_static_site.mjs
@@ -193,6 +193,10 @@ try {
 
 try {
   const version = JSON.parse(fs.readFileSync(versionPath, "utf8"));
+  const versionDate = String(version.date || "");
+  if (versionDate !== "2026-07-05") {
+    fail(`docs/VERSION.json date must match the current public site release date: ${versionDate || "missing"}`);
+  }
   latestRelease = String(version.latest_public_release || "");
   if (!latestRelease) fail("docs/VERSION.json must define latest_public_release");
   instnctAssetVersion = String(version.instnct_asset_version || "");


### PR DESCRIPTION
## Summary
- Update docs/VERSION.json date to 2026-07-05 so release metadata matches the current public site state.
- Add a static-site guard so this release metadata does not silently drift stale again.

## Validation
- node scripts/audit_instnct_static_site.mjs
- node scripts/smoke_public_pages_links.mjs
- python scripts/audit_public_surface.py
- git diff --check

Note: full public export guard is covered by PR CI; local S: drive is space constrained.