### PR TITLE
[codex] Polish INSTNCT release CTA heading

### DIFF
--- a/docs/VERSION.json
+++ b/docs/VERSION.json
@@ -6,7 +6,7 @@
   "pages_surface": "instnct_release_polish",
   "latest_public_release": "public-sdk-p11-20260629",
   "home_asset_version": "home-hero-20260705",
-  "instnct_asset_version": "release-18",
+  "instnct_asset_version": "release-19",
   "anchorcell_asset_version": "research-5",
   "delivery_direction": "proof_materials_before_runtime_terms",
   "crates": [

--- a/docs/instnct/index.html
+++ b/docs/instnct/index.html
@@ -24,9 +24,9 @@
   <meta name="twitter:image" content="https://vraxion.github.io/VRAXION/instnct/assets/instnct-hero-bg.png">
   <meta name="twitter:image:alt" content="INSTNCT local reflex reasoning hero surface">
   <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml">
-  <link rel="stylesheet" href="./styles.css?v=release-18">
+  <link rel="stylesheet" href="./styles.css?v=release-19">
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"INSTNCT","description":"Preview page for the INSTNCT T1 Reflex Engine, VRAXION's first public engine line. No public runnable T1 binary is published yet.","url":"https://vraxion.github.io/VRAXION/instnct/","isPartOf":{"@type":"WebSite","name":"VRAXION","url":"https://vraxion.github.io/VRAXION/"},"author":{"@type":"Person","name":"Daniel Kenessy"},"publisher":{"@type":"Organization","name":"VRAXION","url":"https://vraxion.github.io/VRAXION/"},"about":{"@type":"Thing","name":"INSTNCT T1 Reflex Engine","description":"Local-first reasoning engine target with Path Selector behavior, Exact Mode refusal, bounded results, and offline verification planned for the first signed artifact."}}</script>
-  <script src="./instnct.js?v=release-18" defer></script>
+  <script src="./instnct.js?v=release-19" defer></script>
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
@@ -632,7 +632,7 @@ mode: exact recall</code></pre>
     <section class="section section-dark get-notified" id="get-notified" tabindex="-1" aria-labelledby="notify-title">
       <div class="shell narrow center-heading">
         <p class="kicker cyan">release tracking</p>
-        <h2 id="notify-title">Watch the T1 Reflex Engine.<br><span>Proof Pack first.</span></h2>
+        <h2 id="notify-title">Watch the T1 Reflex Engine.<br> <span>Proof Pack first.</span></h2>
         <p>
           No runnable T1 Reflex Engine binary is public yet. Watch the repo for the Proof Pack: signed artifacts, checksums, release notes, benchmark notes, and public updates.
         </p>


### PR DESCRIPTION
## Summary
- separate the final INSTNCT release CTA heading text so its readable/accessibility fallback is `Watch the T1 Reflex Engine. Proof Pack first.` instead of the concatenated `Engine.Proof`
- bump the INSTNCT cache key to `release-19`

## Validation
- `node scripts/audit_instnct_static_site.mjs`
- `python scripts/audit_public_surface.py`
- `node scripts/smoke_public_pages_links.mjs`
- `node scripts/smoke_instnct_browser.mjs`
- focused heading text check for `notify-title`
- `git diff --check`
- `git diff --cached --check`
- `powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1`