### PR TITLE
[codex] Preload critical public page assets

### DIFF
--- a/docs/anchorcell/index.html
+++ b/docs/anchorcell/index.html
@@ -24,6 +24,9 @@
   <meta name="twitter:image" content="https://vraxion.github.io/VRAXION/assets/vraxion-home-hero.jpg">
   <meta name="twitter:image:alt" content="AnchorCell training data research surface">
   <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml">
+  <link rel="preload" href="../assets/fonts/geist-sans-variable.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="../assets/vraxion-wordmark.webp?v=brand-pass-2" as="image" fetchpriority="high">
+  <link rel="preload" href="../assets/vraxion-home-hero.webp?v=home-hero-20260705" as="image" fetchpriority="high">
   <link rel="stylesheet" href="./styles.css?v=research-5">
   <script src="./anchorcell.js?v=research-5" defer></script>
 </head>
@@ -60,7 +63,7 @@
 
   <section class="hero" id="top" aria-labelledby="hero-title">
     <div class="hero-background" aria-hidden="true">
-      <img src="../assets/vraxion-home-hero.webp?v=home-hero-20260705" alt="" decoding="sync" loading="eager" fetchpriority="high">
+      <img src="../assets/vraxion-home-hero.webp?v=home-hero-20260705" alt="" width="1672" height="941" decoding="sync" loading="eager" fetchpriority="high">
     </div>
     <div class="hero-cursor-glow" aria-hidden="true"></div>
     <div class="hero-inner">

--- a/docs/index.html
+++ b/docs/index.html
@@ -24,6 +24,9 @@
   <meta name="twitter:image" content="https://vraxion.github.io/VRAXION/assets/vraxion-home-hero.jpg">
   <meta name="twitter:image:alt" content="VRAXION local reflex reasoning hero surface">
   <link rel="icon" href="./assets/favicon.svg" type="image/svg+xml">
+  <link rel="preload" href="./assets/fonts/geist-sans-variable.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="./assets/vraxion-home-hero.webp?v=home-hero-20260705" as="image" fetchpriority="high">
+  <link rel="preload" href="./assets/vraxion-wordmark.webp?v=brand-pass-2" as="image" fetchpriority="high">
   <style>
     @font-face {
       font-family: "Geist";
@@ -886,7 +889,7 @@
 
   <section class="hero" id="top" aria-labelledby="hero-title">
     <div class="hero-media" aria-hidden="true">
-      <img src="./assets/vraxion-home-hero.webp?v=home-hero-20260705" alt="" decoding="sync" loading="eager" fetchpriority="high">
+      <img src="./assets/vraxion-home-hero.webp?v=home-hero-20260705" alt="" width="1672" height="941" decoding="sync" loading="eager" fetchpriority="high">
     </div>
     <div class="hero-content">
       <div class="home-badge-row" aria-label="VRAXION engine status">

--- a/docs/instnct/index.html
+++ b/docs/instnct/index.html
@@ -24,6 +24,10 @@
   <meta name="twitter:image" content="https://vraxion.github.io/VRAXION/instnct/assets/instnct-hero-bg.jpg">
   <meta name="twitter:image:alt" content="INSTNCT local reflex reasoning hero surface">
   <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml">
+  <link rel="preload" href="../assets/fonts/geist-sans-variable.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="../assets/vraxion-wordmark.webp?v=brand-pass-2" as="image" fetchpriority="high">
+  <link rel="preload" href="./assets/instnct-hero-bg.webp?v=background-pass-2" as="image" fetchpriority="high">
+  <link rel="preload" href="./assets/instnct-logo.webp?v=logo-pass-2" as="image" fetchpriority="high">
   <link rel="stylesheet" href="./styles.css?v=release-20">
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"INSTNCT","description":"Preview page for the INSTNCT T1 Reflex Engine, VRAXION's first public engine line. No public runnable T1 binary is published yet.","url":"https://vraxion.github.io/VRAXION/instnct/","isPartOf":{"@type":"WebSite","name":"VRAXION","url":"https://vraxion.github.io/VRAXION/"},"author":{"@type":"Person","name":"Daniel Kenessy"},"publisher":{"@type":"Organization","name":"VRAXION","url":"https://vraxion.github.io/VRAXION/"},"about":{"@type":"Thing","name":"INSTNCT T1 Reflex Engine","description":"Local-first reasoning engine target with Path Selector behavior, Exact Mode refusal, bounded results, and offline verification planned for the first signed artifact."}}</script>
   <script src="./instnct.js?v=release-20" defer></script>
@@ -124,7 +128,7 @@
   <main id="main" tabindex="-1">
     <section class="hero" id="intro" aria-labelledby="hero-title">
       <div class="hero-background" aria-hidden="true">
-        <img src="./assets/instnct-hero-bg.webp?v=background-pass-2" alt="" decoding="sync" loading="eager" fetchpriority="high">
+        <img src="./assets/instnct-hero-bg.webp?v=background-pass-2" alt="" width="1672" height="941" decoding="sync" loading="eager" fetchpriority="high">
       </div>
       <div class="hero-cursor-glow" aria-hidden="true"></div>
       <div class="hero-mesh" aria-hidden="true">

--- a/scripts/audit_instnct_static_site.mjs
+++ b/scripts/audit_instnct_static_site.mjs
@@ -57,6 +57,39 @@ function attr(tag, name) {
   return match ? match[1] : "";
 }
 
+function tags(markup, tagName) {
+  return [...markup.matchAll(new RegExp(`<${tagName}\\s+[^>]*>`, "gi"))].map((match) => match[0]);
+}
+
+function requirePreload({ label, markup, href, as, type = "", fetchpriority = "", crossorigin = false }) {
+  const tag = tags(markup, "link").find((candidate) =>
+    /\srel="preload"/i.test(candidate) && attr(candidate, "href") === href
+  );
+  if (!tag) {
+    fail(`${label} critical preload is missing: ${href}`);
+    return;
+  }
+  if (attr(tag, "as") !== as) fail(`${label} preload ${href} must use as="${as}"`);
+  if (type && attr(tag, "type") !== type) fail(`${label} preload ${href} must use type="${type}"`);
+  if (fetchpriority && attr(tag, "fetchpriority") !== fetchpriority) {
+    fail(`${label} preload ${href} must use fetchpriority="${fetchpriority}"`);
+  }
+  if (crossorigin && !/\scrossorigin(?:\s|>|=)/i.test(tag)) {
+    fail(`${label} preload ${href} must include crossorigin`);
+  }
+}
+
+function requireImageDimensions({ label, markup, src, width, height }) {
+  const tag = tags(markup, "img").find((candidate) => attr(candidate, "src") === src);
+  if (!tag) {
+    fail(`${label} image is missing: ${src}`);
+    return;
+  }
+  if (attr(tag, "width") !== String(width) || attr(tag, "height") !== String(height)) {
+    fail(`${label} image ${src} must declare intrinsic dimensions ${width}x${height}`);
+  }
+}
+
 function isExternalRef(value) {
   return /^(?:https?:)?\/\//i.test(value);
 }
@@ -1056,12 +1089,42 @@ validateSocialImage({
 });
 
 if (homeAssetVersion) {
-  if (!home.includes(`./assets/vraxion-home-hero.webp?v=${homeAssetVersion}`)) {
+  const homeHeroRef = `./assets/vraxion-home-hero.webp?v=${homeAssetVersion}`;
+  const anchorcellHeroRef = `../assets/vraxion-home-hero.webp?v=${homeAssetVersion}`;
+  if (!home.includes(homeHeroRef)) {
     fail("homepage hero image cache key must match docs/VERSION.json home_asset_version");
   }
-  if (!anchorcell.includes(`../assets/vraxion-home-hero.webp?v=${homeAssetVersion}`)) {
+  if (!anchorcell.includes(anchorcellHeroRef)) {
     fail("AnchorCell hero image cache key must match docs/VERSION.json home_asset_version");
   }
+  requirePreload({
+    label: "homepage",
+    markup: home,
+    href: homeHeroRef,
+    as: "image",
+    fetchpriority: "high",
+  });
+  requirePreload({
+    label: "AnchorCell",
+    markup: anchorcell,
+    href: anchorcellHeroRef,
+    as: "image",
+    fetchpriority: "high",
+  });
+  requireImageDimensions({
+    label: "homepage hero",
+    markup: home,
+    src: homeHeroRef,
+    width: 1672,
+    height: 941,
+  });
+  requireImageDimensions({
+    label: "AnchorCell hero",
+    markup: anchorcell,
+    src: anchorcellHeroRef,
+    width: 1672,
+    height: 941,
+  });
 }
 
 if (anchorcellAssetVersion) {
@@ -1072,6 +1135,65 @@ if (anchorcellAssetVersion) {
     fail("AnchorCell script cache key must match docs/VERSION.json anchorcell_asset_version");
   }
 }
+
+for (const { label, markup, fontRef, wordmarkRef } of [
+  {
+    label: "homepage",
+    markup: home,
+    fontRef: "./assets/fonts/geist-sans-variable.woff2",
+    wordmarkRef: "./assets/vraxion-wordmark.webp?v=brand-pass-2",
+  },
+  {
+    label: "INSTNCT",
+    markup: html,
+    fontRef: "../assets/fonts/geist-sans-variable.woff2",
+    wordmarkRef: "../assets/vraxion-wordmark.webp?v=brand-pass-2",
+  },
+  {
+    label: "AnchorCell",
+    markup: anchorcell,
+    fontRef: "../assets/fonts/geist-sans-variable.woff2",
+    wordmarkRef: "../assets/vraxion-wordmark.webp?v=brand-pass-2",
+  },
+]) {
+  requirePreload({
+    label,
+    markup,
+    href: fontRef,
+    as: "font",
+    type: "font/woff2",
+    crossorigin: true,
+  });
+  requirePreload({
+    label,
+    markup,
+    href: wordmarkRef,
+    as: "image",
+    fetchpriority: "high",
+  });
+}
+
+requirePreload({
+  label: "INSTNCT",
+  markup: html,
+  href: "./assets/instnct-hero-bg.webp?v=background-pass-2",
+  as: "image",
+  fetchpriority: "high",
+});
+requirePreload({
+  label: "INSTNCT",
+  markup: html,
+  href: "./assets/instnct-logo.webp?v=logo-pass-2",
+  as: "image",
+  fetchpriority: "high",
+});
+requireImageDimensions({
+  label: "INSTNCT hero",
+  markup: html,
+  src: "./assets/instnct-hero-bg.webp?v=background-pass-2",
+  width: 1672,
+  height: 941,
+});
 
 if (/\.hero-mesh\s*\{[^}]*display:\s*none/i.test(css)) {
   fail("hero mesh should not be fully disabled in responsive CSS");


### PR DESCRIPTION
## Summary
- add critical font, hero, and wordmark/logo preloads to the home, INSTNCT, and AnchorCell public pages
- declare intrinsic dimensions on decorative hero images to keep first-screen layout stable
- extend the static site audit to require matching preloads, high fetch priority, font crossorigin, and hero image dimensions

## Validation
- git diff --check
- git diff --cached --check
- node scripts\\audit_instnct_static_site.mjs
- node scripts\\smoke_instnct_browser.mjs
- python scripts\\audit_public_surface.py
- powershell -ExecutionPolicy Bypass -File scripts\\check_public_export.ps1