### PR TITLE
[codex] Tighten AnchorCell metadata snippet

### DIFF
--- a/docs/anchorcell/index.html
+++ b/docs/anchorcell/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'; upgrade-insecure-requests">
   <title>AnchorCell - VRAXION Training Data Research</title>
-  <meta name="description" content="AnchorCell is a Vraxion research direction for structured training-data authoring: scoped decision cells with trust separation, evidence links, adversarial branches, and tested export views.">
+  <meta name="description" content="AnchorCell is VRAXION research for structured training-data authoring: scoped decision cells with trust separation, evidence links, adversarial branches, and tested exports.">
   <meta name="theme-color" content="#05080a">
   <meta name="robots" content="index,follow">
   <link rel="canonical" href="https://vraxion.github.io/VRAXION/anchorcell/">

--- a/scripts/audit_instnct_static_site.mjs
+++ b/scripts/audit_instnct_static_site.mjs
@@ -136,6 +136,13 @@ function metaContentFor(label, markup, name) {
   return match ? match[1] : "";
 }
 
+function validateMetaDescription({ label, markup }) {
+  const description = metaContentFor(label, markup, "description");
+  if (description.length < 80 || description.length > 180) {
+    fail(`${label} meta description should stay between 80 and 180 characters; got ${description.length}`);
+  }
+}
+
 function pngSize(filePath) {
   const buf = fs.readFileSync(filePath);
   const signature = "89504e470d0a1a0a";
@@ -1087,6 +1094,14 @@ validateSocialImage({
   rootDir: docsRoot,
   expectedAlt: "AnchorCell training data research surface",
 });
+
+for (const [label, markup] of [
+  ["homepage", home],
+  ["INSTNCT", html],
+  ["AnchorCell", anchorcell],
+]) {
+  validateMetaDescription({ label, markup });
+}
 
 if (homeAssetVersion) {
   const homeHeroRef = `./assets/vraxion-home-hero.webp?v=${homeAssetVersion}`;


### PR DESCRIPTION
## Summary
- shorten the AnchorCell meta description into a cleaner social/search snippet range
- normalize the brand casing to VRAXION in the metadata
- add a static audit guard requiring public page meta descriptions to stay between 80 and 180 characters

## Validation
- git diff --check
- git diff --cached --check
- node scripts\\audit_instnct_static_site.mjs
- semantic/a11y HTML smoke
- node scripts\\smoke_instnct_browser.mjs
- python scripts\\audit_public_surface.py
- powershell -ExecutionPolicy Bypass -File scripts\\check_public_export.ps1