### PR TITLE
[codex] Add public pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Public Scope
+
+- What exactly becomes public?
+- What stays private?
+- Which user-facing claim changes, if any?
+
+## Release Intake
+
+- [ ] This PR does not add private engine source, non-public training data, raw operator output, local paths, secrets, or filled production config.
+- [ ] `PUBLIC_RELEASE_CHECKLIST.md` was followed, or this PR does not change release status, artifacts, downloads, or public claims.
+- [ ] Any generated local config, including `workers/instnct-notify/wrangler.jsonc`, remains untracked.
+- [ ] Any new artifact has public-safe provenance, naming, and checksum or signature material where applicable.
+
+## Required Public Gates
+
+- [ ] `node scripts\sync_public_release_links.mjs --check`
+- [ ] `node scripts\audit_instnct_static_site.mjs`
+- [ ] `node scripts\audit_instnct_notify_worker.mjs`
+- [ ] `python scripts\audit_public_surface.py`
+- [ ] `node scripts\smoke_public_pages_links.mjs`
+- [ ] `powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1`
+
+## Notes
+
+- Source-of-truth release, artifact, checksum, or docs page:
+- Intentional unchanged release files:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,3 +23,6 @@ tools to this repository.
 Release PRs must also follow `PUBLIC_RELEASE_CHECKLIST.md`. If a release
 changes public status, artifacts, downloads, or claims, state exactly what
 became public and what stayed private in the PR body.
+
+Use the GitHub pull request template. Do not delete the public scope,
+release-intake, or required-gates sections from release or public-surface PRs.

--- a/scripts/audit_public_surface.py
+++ b/scripts/audit_public_surface.py
@@ -86,6 +86,7 @@ FORBIDDEN_PUBLIC_COPY = [
 EXPECTED_CRATES = {"alphasync-core", "alphasync-runtime"}
 
 REQUIRED_TRACKED_FILES = {
+    ".github/pull_request_template.md",
     ".gitattributes",
     ".gitignore",
     "README.md",
@@ -94,6 +95,14 @@ REQUIRED_TRACKED_FILES = {
     "PUBLIC_DELIVERY_MODEL.md",
     "PUBLIC_RELEASE_CHECKLIST.md",
     "LICENSE_BOUNDARY.md",
+}
+
+REQUIRED_PR_TEMPLATE_MARKERS = {
+    "What exactly becomes public?",
+    "What stays private?",
+    "PUBLIC_RELEASE_CHECKLIST.md",
+    "workers/instnct-notify/wrangler.jsonc",
+    "powershell -ExecutionPolicy Bypass -File scripts\\check_public_export.ps1",
 }
 
 REQUIRED_GITATTRIBUTES_ENTRIES = {
@@ -169,6 +178,11 @@ def main() -> int:
     for required in sorted(REQUIRED_TRACKED_FILES):
         if required not in file_set:
             failures.append(f"required public repo file is missing: {required}")
+
+    pr_template = read_text(ROOT / ".github" / "pull_request_template.md")
+    for required in sorted(REQUIRED_PR_TEMPLATE_MARKERS):
+        if required not in pr_template:
+            failures.append(f"pull request template missing release guard marker: {required}")
 
     gitattributes_path = ROOT / ".gitattributes"
     gitattributes_entries = {

--- a/scripts/check_public_export.ps1
+++ b/scripts/check_public_export.ps1
@@ -309,6 +309,7 @@ try {
     Write-Host "==> public export root shape"
     Assert-NoReparsePoints -Root $exportPath
     $requiredRootEntries = @(
+        ".github\pull_request_template.md",
         ".github\workflows\ci.yml",
         ".github\workflows\deploy-instnct-notify.yml",
         ".github\workflows\public-pages-smoke.yml",
@@ -412,6 +413,7 @@ try {
 
     Write-Host "==> public export exact path allowlist"
     $allowedPublicFiles = @(
+        ".github/pull_request_template.md",
         ".github/workflows/ci.yml",
         ".github/workflows/deploy-instnct-notify.yml",
         ".github/workflows/public-pages-smoke.yml",


### PR DESCRIPTION
Adds a GitHub pull request template that forces public/private scope, release intake, and required public gates into future PRs. The public surface audit now requires the template and checks key release-guard markers, while the export guard allowlist includes it as part of the maintained public repo surface. Validated locally with public surface audit, INSTNCT static audit, notify worker audit, release link check, public pages link smoke, diff check, and full public export guard.