### PR TITLE
[codex] Add public issue intake guard

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security report
+    url: https://github.com/VRAXION/VRAXION/security/policy
+    about: Use SECURITY.md for vulnerabilities or reports with security impact.
+  - name: Public release checklist
+    url: https://github.com/VRAXION/VRAXION/blob/main/PUBLIC_RELEASE_CHECKLIST.md
+    about: Review the release intake rules before proposing a public artifact or claim change.

--- a/.github/ISSUE_TEMPLATE/public-surface-report.yml
+++ b/.github/ISSUE_TEMPLATE/public-surface-report.yml
@@ -1,0 +1,57 @@
+name: Public surface report
+description: Report a public docs, site, crate, or worker example issue without private material.
+title: "[public surface] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form only for the visible public surface: docs, GitHub Pages, public crates, examples, release notes, and public workflow behavior.
+
+        Do not paste secrets, tokens, private code, non-public training data, raw operator output, local machine paths, production config, or private dashboards. If the report has security impact, use SECURITY.md instead of a public issue.
+  - type: dropdown
+    id: public_area
+    attributes:
+      label: Public area
+      description: Which public surface needs attention?
+      options:
+        - Root docs or policy
+        - GitHub Pages site
+        - Public crate or package metadata
+        - Worker example or deployment docs
+        - Release notes, checksum, or artifact docs
+        - Public workflow or guard script
+    validations:
+      required: true
+  - type: textarea
+    id: observed
+    attributes:
+      label: What is wrong?
+      description: Describe only public behavior or public files.
+      placeholder: The public page, docs file, crate metadata, or release note says...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected public result
+      description: State the public-safe correction or expected behavior.
+      placeholder: It should instead say, link to, or validate...
+    validations:
+      required: true
+  - type: textarea
+    id: public_refs
+    attributes:
+      label: Public references
+      description: Add only public URLs, issue links, release links, or repo-relative paths.
+      placeholder: README.md, docs/index.html, a public release tag, or a public page URL.
+    validations:
+      required: false
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Public-safety confirmation
+      options:
+        - label: I did not include secrets, tokens, private code, non-public training data, local machine paths, raw operator output, production config, or private dashboards.
+          required: true
+        - label: I will use SECURITY.md instead of a public issue if this has security impact.
+          required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   repo hygiene files.
 - Reworked the root README into a clearer public release intake entrypoint.
 - Added `PUBLIC_RELEASE_CHECKLIST.md` for future release PRs.
+- Added a public issue intake form and guard checks that keep reports inside
+  the visible public surface.
 
 ## 2026-06-29
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,3 +26,8 @@ became public and what stayed private in the PR body.
 
 Use the GitHub pull request template. Do not delete the public scope,
 release-intake, or required-gates sections from release or public-surface PRs.
+
+Use the GitHub issue form for public reports. Do not put secrets, private code,
+non-public training data, local machine paths, raw operator output, production
+config, or private dashboards in public issues. Use `SECURITY.md` for
+vulnerabilities or reports with security impact.

--- a/scripts/audit_public_surface.py
+++ b/scripts/audit_public_surface.py
@@ -86,6 +86,8 @@ FORBIDDEN_PUBLIC_COPY = [
 EXPECTED_CRATES = {"alphasync-core", "alphasync-runtime"}
 
 REQUIRED_TRACKED_FILES = {
+    ".github/ISSUE_TEMPLATE/config.yml",
+    ".github/ISSUE_TEMPLATE/public-surface-report.yml",
     ".github/pull_request_template.md",
     ".gitattributes",
     ".gitignore",
@@ -103,6 +105,21 @@ REQUIRED_PR_TEMPLATE_MARKERS = {
     "PUBLIC_RELEASE_CHECKLIST.md",
     "workers/instnct-notify/wrangler.jsonc",
     "powershell -ExecutionPolicy Bypass -File scripts\\check_public_export.ps1",
+}
+
+REQUIRED_ISSUE_TEMPLATE_MARKERS = {
+    "Do not paste secrets",
+    "SECURITY.md",
+    "local machine paths",
+    "non-public training data",
+    "public surface",
+    "raw operator output",
+}
+
+REQUIRED_ISSUE_CONFIG_MARKERS = {
+    "PUBLIC_RELEASE_CHECKLIST.md",
+    "blank_issues_enabled: false",
+    "security/policy",
 }
 
 REQUIRED_GITATTRIBUTES_ENTRIES = {
@@ -183,6 +200,18 @@ def main() -> int:
     for required in sorted(REQUIRED_PR_TEMPLATE_MARKERS):
         if required not in pr_template:
             failures.append(f"pull request template missing release guard marker: {required}")
+
+    issue_template = read_text(
+        ROOT / ".github" / "ISSUE_TEMPLATE" / "public-surface-report.yml"
+    )
+    for required in sorted(REQUIRED_ISSUE_TEMPLATE_MARKERS):
+        if required not in issue_template:
+            failures.append(f"issue template missing public-safety marker: {required}")
+
+    issue_config = read_text(ROOT / ".github" / "ISSUE_TEMPLATE" / "config.yml")
+    for required in sorted(REQUIRED_ISSUE_CONFIG_MARKERS):
+        if required not in issue_config:
+            failures.append(f"issue template config missing intake marker: {required}")
 
     gitattributes_path = ROOT / ".gitattributes"
     gitattributes_entries = {

--- a/scripts/check_public_export.ps1
+++ b/scripts/check_public_export.ps1
@@ -309,6 +309,8 @@ try {
     Write-Host "==> public export root shape"
     Assert-NoReparsePoints -Root $exportPath
     $requiredRootEntries = @(
+        ".github\ISSUE_TEMPLATE\config.yml",
+        ".github\ISSUE_TEMPLATE\public-surface-report.yml",
         ".github\pull_request_template.md",
         ".github\workflows\ci.yml",
         ".github\workflows\deploy-instnct-notify.yml",
@@ -413,6 +415,8 @@ try {
 
     Write-Host "==> public export exact path allowlist"
     $allowedPublicFiles = @(
+        ".github/ISSUE_TEMPLATE/config.yml",
+        ".github/ISSUE_TEMPLATE/public-surface-report.yml",
         ".github/pull_request_template.md",
         ".github/workflows/ci.yml",
         ".github/workflows/deploy-instnct-notify.yml",


### PR DESCRIPTION
## Summary
- add a public issue form that blocks private material from ordinary reports
- disable blank issues and route security reports through SECURITY.md
- make the issue intake files required by the public surface audit and exact export allowlist

## Verification
- python scripts\\audit_public_surface.py
- node scripts\\audit_instnct_static_site.mjs
- node scripts\\audit_instnct_notify_worker.mjs
- node scripts\\sync_public_release_links.mjs --check
- node scripts\\smoke_public_pages_links.mjs
- git diff --cached --check
- powershell -ExecutionPolicy Bypass -File scripts\\check_public_export.ps1