### PR TITLE
[codex] Add public dependency maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Budapest"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "public-surface"
+    commit-message:
+      prefix: "[deps]"
+    groups:
+      rust-public-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:20"
+      timezone: "Europe/Budapest"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "public-surface"
+    commit-message:
+      prefix: "[deps]"
+    groups:
+      public-github-actions:
+        patterns:
+          - "*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   reports without exposing private material.
 - Added `PUBLIC_GITHUB_STATE.md` to define current public GitHub release, tag,
   asset, and Pages review rules.
+- Added Dependabot maintenance for the public Cargo workspace and GitHub
+  Actions surface.
 
 ## 2026-06-29
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,3 +32,7 @@ non-public training data, local machine paths, raw operator output, production
 config, or private dashboards in public issues. Use `SECURITY.md` for
 vulnerabilities or reports with security impact. Support routing is summarized
 in `SUPPORT.md`.
+
+Dependency update PRs are public-surface PRs. Keep them limited to the public
+Cargo workspace and GitHub Actions unless a separate release review adds a new
+public manifest or ecosystem.

--- a/PUBLIC_GITHUB_STATE.md
+++ b/PUBLIC_GITHUB_STATE.md
@@ -30,6 +30,7 @@ Before creating or updating a public release, review:
 - attached release assets, if any
 - tag name and target commit
 - default branch and branch list
+- Dependabot or dependency-update PRs that may affect the public build
 - Pages deployment target
 - public status docs and release links
 
@@ -37,6 +38,8 @@ Before creating or updating a public release, review:
 
 - Keep release metadata and assets aligned with `docs/VERSION.json`.
 - Keep `PUBLIC_RELEASE_CHECKLIST.md` as the release intake gate.
+- Keep dependency update automation limited to public manifests and GitHub
+  Actions.
 - Keep private engine source, non-public training data, raw operator output,
   local machine paths, secrets, filled production config, and private
   dashboards out of public GitHub issues, pull requests, releases, assets, and

--- a/scripts/audit_public_surface.py
+++ b/scripts/audit_public_surface.py
@@ -86,6 +86,7 @@ FORBIDDEN_PUBLIC_COPY = [
 EXPECTED_CRATES = {"alphasync-core", "alphasync-runtime"}
 
 REQUIRED_TRACKED_FILES = {
+    ".github/dependabot.yml",
     ".github/ISSUE_TEMPLATE/config.yml",
     ".github/ISSUE_TEMPLATE/public-surface-report.yml",
     ".github/pull_request_template.md",
@@ -110,6 +111,17 @@ REQUIRED_PR_TEMPLATE_MARKERS = {
     "powershell -ExecutionPolicy Bypass -File scripts\\check_public_export.ps1",
 }
 
+REQUIRED_DEPENDABOT_MARKERS = {
+    "directory: \"/\"",
+    "github-actions",
+    "open-pull-requests-limit: 5",
+    "package-ecosystem: \"cargo\"",
+    "public-github-actions",
+    "public-surface",
+    "rust-public-dependencies",
+    "timezone: \"Europe/Budapest\"",
+}
+
 REQUIRED_GITHUB_STATE_MARKERS = {
     "## Current Public Truth",
     "## Historical GitHub Records",
@@ -118,6 +130,7 @@ REQUIRED_GITHUB_STATE_MARKERS = {
     "gh release list --limit 20",
     "latest public release: `public-sdk-p11-20260629`",
     "non-public training data",
+    "public manifests and GitHub",
     "release metadata and assets",
 }
 
@@ -224,6 +237,11 @@ def main() -> int:
     for required in sorted(REQUIRED_PR_TEMPLATE_MARKERS):
         if required not in pr_template:
             failures.append(f"pull request template missing release guard marker: {required}")
+
+    dependabot_config = read_text(ROOT / ".github" / "dependabot.yml")
+    for required in sorted(REQUIRED_DEPENDABOT_MARKERS):
+        if required not in dependabot_config:
+            failures.append(f"dependabot config missing public dependency marker: {required}")
 
     github_state_doc = read_text(ROOT / "PUBLIC_GITHUB_STATE.md")
     for required in sorted(REQUIRED_GITHUB_STATE_MARKERS):

--- a/scripts/check_public_export.ps1
+++ b/scripts/check_public_export.ps1
@@ -309,6 +309,7 @@ try {
     Write-Host "==> public export root shape"
     Assert-NoReparsePoints -Root $exportPath
     $requiredRootEntries = @(
+        ".github\dependabot.yml",
         ".github\ISSUE_TEMPLATE\config.yml",
         ".github\ISSUE_TEMPLATE\public-surface-report.yml",
         ".github\pull_request_template.md",
@@ -417,6 +418,7 @@ try {
 
     Write-Host "==> public export exact path allowlist"
     $allowedPublicFiles = @(
+        ".github/dependabot.yml",
         ".github/ISSUE_TEMPLATE/config.yml",
         ".github/ISSUE_TEMPLATE/public-surface-report.yml",
         ".github/pull_request_template.md",


### PR DESCRIPTION
## Summary
- add Dependabot maintenance for the public Cargo workspace and GitHub Actions
- document dependency-update PRs as public-surface PRs
- require the Dependabot config through public surface audit and exact export allowlist

## Verification
- python scripts\\audit_public_surface.py
- node scripts\\audit_instnct_static_site.mjs
- node scripts\\audit_instnct_notify_worker.mjs
- node scripts\\sync_public_release_links.mjs --check
- node scripts\\smoke_public_pages_links.mjs
- git diff --cached --check
- powershell -ExecutionPolicy Bypass -File scripts\\check_public_export.ps1