### PR TITLE
[codex] Remove stale public wording

### DIFF
--- a/docs/ANCHORCELL_RESEARCH_BRIEF.md
+++ b/docs/ANCHORCELL_RESEARCH_BRIEF.md
@@ -82,7 +82,7 @@ The public view should be a product of the export compiler, not a manually clean
 
 The current public baseline is `docs/anchorcell/anchorcell.v2.schema.json`: a JSON Schema Draft 2020-12 authoring schema for `alphasync.anchorcell.v2` records. It is strict by default: top-level records are closed, important fields are bounded, IDs and timestamps are canonicalized, branch roles are required, every branch carries at least one evidence reference, and accepted/training/public-export states are gated by review and security flags.
 
-The companion example is `docs/anchorcell/anchorcell.v2.example.json`: a synthetic access-control decision cell that shows the intended shape of one accepted, public-redacted AnchorCell without exposing private repository data, secrets, or real user material.
+The companion example is `docs/anchorcell/anchorcell.v2.example.json`: a synthetic access-control decision cell that shows the intended shape of one accepted, public-redacted AnchorCell without exposing non-public project data, secrets, or real user material.
 
 The schema is intentionally syntactic. It can prove shape, required fields, enums, caps, forbidden hidden-reasoning fields, and many state gates. It should not pretend to prove graph facts by itself. Cross-record rules still belong in semantic lint: parent existence, parent-is-not-self, evidence references resolving to real facts, branch ID uniqueness by key, variant consistency, leakage checks, and export compiler checks.
 

--- a/scripts/check_public_export.ps1
+++ b/scripts/check_public_export.ps1
@@ -695,7 +695,7 @@ try {
         Invoke-Checked "cargo package alphasync-core archive" {
             cargo package -p alphasync-core --allow-dirty --no-verify --target-dir $archiveTarget | Out-Null
         }
-        Invoke-Checked "create alphasync-runtime source archive" {
+        Invoke-Checked "create alphasync-runtime crate bundle" {
             $runtimeArchivePackageDir = Join-Path $archiveTarget "package"
             $runtimeArchiveStaging = Join-Path $archiveVerifyRoot "runtime_archive"
             $runtimeArchiveSource = Join-Path $runtimeArchiveStaging "alphasync-runtime-0.1.0"


### PR DESCRIPTION
## Summary
- replace private-repo wording in the public AnchorCell research brief with neutral non-public project wording
- rename the public export guard log step from source archive to crate bundle

## Verification
- python scripts/audit_public_surface.py
- powershell -ExecutionPolicy Bypass -File scripts/check_public_export.ps1