### PR TITLE
[codex] Add public CODEOWNERS guard

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,25 @@
+# Public repository ownership.
+# GitHub uses the last matching pattern. Keep explicit sections so release
+# review scope stays obvious when public artifacts or status claims change.
+
+* @Kenessy
+
+/.github/ @Kenessy
+/scripts/ @Kenessy
+/docs/ @Kenessy
+/workers/instnct-notify/ @Kenessy
+/crates/ @Kenessy
+
+/Cargo.lock @Kenessy
+/Cargo.toml @Kenessy
+/CHANGELOG.md @Kenessy
+/CODE_OF_CONDUCT.md @Kenessy
+/CONTRIBUTING.md @Kenessy
+/LICENSE_BOUNDARY.md @Kenessy
+/PACKAGE_BOUNDARY.md @Kenessy
+/PUBLIC_*.md @Kenessy
+/README.md @Kenessy
+/SECURITY.md @Kenessy
+/SUPPORT.md @Kenessy
+/TRADEMARK_POLICY.md @Kenessy
+/docs/VERSION.json @Kenessy

--- a/PUBLIC_GITHUB_STATE.md
+++ b/PUBLIC_GITHUB_STATE.md
@@ -30,6 +30,7 @@ Before creating or updating a public release, review:
 - attached release assets, if any
 - tag name and target commit
 - default branch and branch list
+- CODEOWNERS routing for public boundary, release, workflow, and docs changes
 - Dependabot or dependency-update PRs that may affect the public build
 - Pages deployment target
 - public status docs and release links
@@ -38,6 +39,8 @@ Before creating or updating a public release, review:
 
 - Keep release metadata and assets aligned with `docs/VERSION.json`.
 - Keep `PUBLIC_RELEASE_CHECKLIST.md` as the release intake gate.
+- Keep `.github/CODEOWNERS` routing public boundary, workflow, docs, Worker, and
+  crate changes to the public repo owner.
 - Keep dependency update automation limited to public manifests and GitHub
   Actions.
 - Keep private engine source, non-public training data, raw operator output,

--- a/scripts/audit_public_surface.py
+++ b/scripts/audit_public_surface.py
@@ -86,6 +86,7 @@ FORBIDDEN_PUBLIC_COPY = [
 EXPECTED_CRATES = {"alphasync-core", "alphasync-runtime"}
 
 REQUIRED_TRACKED_FILES = {
+    ".github/CODEOWNERS",
     ".github/dependabot.yml",
     ".github/ISSUE_TEMPLATE/config.yml",
     ".github/ISSUE_TEMPLATE/public-surface-report.yml",
@@ -122,9 +123,21 @@ REQUIRED_DEPENDABOT_MARKERS = {
     "timezone: \"Europe/Budapest\"",
 }
 
+REQUIRED_CODEOWNERS_MARKERS = {
+    "* @Kenessy",
+    "/.github/ @Kenessy",
+    "/scripts/ @Kenessy",
+    "/docs/ @Kenessy",
+    "/workers/instnct-notify/ @Kenessy",
+    "/crates/ @Kenessy",
+    "/PUBLIC_*.md @Kenessy",
+    "/docs/VERSION.json @Kenessy",
+}
+
 REQUIRED_GITHUB_STATE_MARKERS = {
     "## Current Public Truth",
     "## Historical GitHub Records",
+    ".github/CODEOWNERS",
     "PUBLIC_RELEASE_CHECKLIST.md",
     "docs/VERSION.json",
     "gh release list --limit 20",
@@ -262,6 +275,11 @@ def main() -> int:
     for required in sorted(REQUIRED_DEPENDABOT_MARKERS):
         if required not in dependabot_config:
             failures.append(f"dependabot config missing public dependency marker: {required}")
+
+    codeowners = read_text(ROOT / ".github" / "CODEOWNERS")
+    for required in sorted(REQUIRED_CODEOWNERS_MARKERS):
+        if required not in codeowners:
+            failures.append(f"CODEOWNERS missing public ownership marker: {required}")
 
     github_state_doc = read_text(ROOT / "PUBLIC_GITHUB_STATE.md")
     for required in sorted(REQUIRED_GITHUB_STATE_MARKERS):

--- a/scripts/check_public_export.ps1
+++ b/scripts/check_public_export.ps1
@@ -309,6 +309,7 @@ try {
     Write-Host "==> public export root shape"
     Assert-NoReparsePoints -Root $exportPath
     $requiredRootEntries = @(
+        ".github\CODEOWNERS",
         ".github\dependabot.yml",
         ".github\ISSUE_TEMPLATE\config.yml",
         ".github\ISSUE_TEMPLATE\public-surface-report.yml",
@@ -418,6 +419,7 @@ try {
 
     Write-Host "==> public export exact path allowlist"
     $allowedPublicFiles = @(
+        ".github/CODEOWNERS",
         ".github/dependabot.yml",
         ".github/ISSUE_TEMPLATE/config.yml",
         ".github/ISSUE_TEMPLATE/public-surface-report.yml",


### PR DESCRIPTION
## Summary
- add `.github/CODEOWNERS` so public boundary, docs, workflow, Worker, and crate changes route to the public repo owner
- document CODEOWNERS review routing in `PUBLIC_GITHUB_STATE.md`
- make CODEOWNERS presence and key routes part of `audit_public_surface.py` and the full public export allowlist

## Verification
- `python scripts\audit_public_surface.py`
- `powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1`