### PR TITLE
[codex] Add public release state validator

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,7 @@
 
 - [ ] `node scripts\sync_public_release_links.mjs --check`
 - [ ] `node scripts\validate_public_release_manifests.mjs`
+- [ ] `node scripts\validate_public_release_state.mjs`
 - [ ] `node scripts\audit_instnct_static_site.mjs`
 - [ ] `node scripts\audit_instnct_notify_worker.mjs`
 - [ ] `python scripts\audit_public_surface.py`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,14 @@ jobs:
           node --check scripts/audit_instnct_notify_worker.mjs
           node --check scripts/sync_public_release_links.mjs
           node --check scripts/validate_public_release_manifests.mjs
+          node --check scripts/validate_public_release_state.mjs
           node --check scripts/smoke_instnct_notify_live.mjs
           node --check scripts/smoke_public_pages_links.mjs
           node --check scripts/smoke_instnct_browser.mjs
           node --check docs/instnct/instnct.js
           node scripts/sync_public_release_links.mjs --check
           node scripts/validate_public_release_manifests.mjs
+          node scripts/validate_public_release_state.mjs
           node scripts/audit_instnct_static_site.mjs
           node scripts/audit_instnct_notify_worker.mjs
       - name: INSTNCT browser smoke

--- a/.github/workflows/public-surface-audit.yml
+++ b/.github/workflows/public-surface-audit.yml
@@ -20,5 +20,7 @@ jobs:
           python-version: "3.x"
       - name: Validate public release manifests
         run: node scripts/validate_public_release_manifests.mjs
+      - name: Validate public release state
+        run: node scripts/validate_public_release_state.mjs
       - name: Audit public surface
         run: python scripts/audit_public_surface.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   future artifact/checksum/signature intake.
 - Added a public release manifest validator and CI gate for future release
   artifact intake.
+- Added a public release state validator and CI gate to keep the public version
+  record, GitHub release pointer, status docs, and Pages copy aligned.
 
 ## 2026-06-29
 

--- a/PUBLIC_GITHUB_STATE.md
+++ b/PUBLIC_GITHUB_STATE.md
@@ -66,6 +66,7 @@ GitHub state before merge:
 gh pr list --state open --limit 50
 gh release list --limit 20
 node scripts\sync_public_release_links.mjs --check
+node scripts\validate_public_release_state.mjs
 python scripts\audit_public_surface.py
 powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1
 ```

--- a/PUBLIC_RELEASE_CHECKLIST.md
+++ b/PUBLIC_RELEASE_CHECKLIST.md
@@ -89,6 +89,7 @@ Run these before opening or merging the release PR:
 ```powershell
 node scripts\sync_public_release_links.mjs --check
 node scripts\validate_public_release_manifests.mjs
+node scripts\validate_public_release_state.mjs
 node scripts\audit_instnct_static_site.mjs
 node scripts\audit_instnct_notify_worker.mjs
 python scripts\audit_public_surface.py

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ cargo test --doc --workspace --all-features
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo doc --workspace --no-deps
 node scripts/validate_public_release_manifests.mjs
+node scripts/validate_public_release_state.mjs
 python scripts/audit_public_surface.py
 powershell -ExecutionPolicy Bypass -File scripts/check_public_export.ps1
 ```

--- a/scripts/audit_public_surface.py
+++ b/scripts/audit_public_surface.py
@@ -103,6 +103,7 @@ REQUIRED_TRACKED_FILES = {
     "releases/public-release-manifest.example.json",
     "releases/public-release-manifest.schema.json",
     "scripts/validate_public_release_manifests.mjs",
+    "scripts/validate_public_release_state.mjs",
     "LICENSE_BOUNDARY.md",
     "SUPPORT.md",
 }
@@ -115,6 +116,7 @@ REQUIRED_PR_TEMPLATE_MARKERS = {
     "Release manifest checked:",
     "releases/public-release-manifest.schema.json",
     "node scripts\\validate_public_release_manifests.mjs",
+    "node scripts\\validate_public_release_state.mjs",
     "workers/instnct-notify/wrangler.jsonc",
     "powershell -ExecutionPolicy Bypass -File scripts\\check_public_export.ps1",
 }
@@ -153,6 +155,7 @@ REQUIRED_GITHUB_STATE_MARKERS = {
     "public manifests and GitHub",
     "release metadata and assets",
     "releases/public-release-manifest.schema.json",
+    "node scripts\\validate_public_release_state.mjs",
 }
 
 REQUIRED_RELEASE_MANIFEST_README_MARKERS = {

--- a/scripts/check_public_export.ps1
+++ b/scripts/check_public_export.ps1
@@ -394,6 +394,7 @@ try {
         "scripts\audit_public_surface.py",
         "scripts\check_public_export.ps1",
         "scripts\validate_public_release_manifests.mjs",
+        "scripts\validate_public_release_state.mjs",
         "scripts\smoke_instnct_notify_live.mjs",
         "scripts\smoke_public_pages_links.mjs",
         "scripts\smoke_instnct_browser.mjs",
@@ -506,6 +507,7 @@ try {
         "scripts/audit_public_surface.py",
         "scripts/check_public_export.ps1",
         "scripts/validate_public_release_manifests.mjs",
+        "scripts/validate_public_release_state.mjs",
         "scripts/smoke_instnct_notify_live.mjs",
         "scripts/smoke_public_pages_links.mjs",
         "scripts/smoke_instnct_browser.mjs",
@@ -594,12 +596,14 @@ try {
     Invoke-NativeChecked "node check audit_instnct_notify_worker" "node" @("--check", "scripts/audit_instnct_notify_worker.mjs")
     Invoke-NativeChecked "node check sync_public_release_links" "node" @("--check", "scripts/sync_public_release_links.mjs")
     Invoke-NativeChecked "node check validate_public_release_manifests" "node" @("--check", "scripts/validate_public_release_manifests.mjs")
+    Invoke-NativeChecked "node check validate_public_release_state" "node" @("--check", "scripts/validate_public_release_state.mjs")
     Invoke-NativeChecked "node check smoke_public_pages_links" "node" @("--check", "scripts/smoke_public_pages_links.mjs")
     Invoke-NativeChecked "node check smoke_instnct_notify_live" "node" @("--check", "scripts/smoke_instnct_notify_live.mjs")
     Invoke-NativeChecked "node check smoke_instnct_browser" "node" @("--check", "scripts/smoke_instnct_browser.mjs")
     Invoke-NativeChecked "node check instnct client JS" "node" @("--check", "docs/instnct/instnct.js")
     Invoke-NativeChecked "sync public release links" "node" @("scripts/sync_public_release_links.mjs", "--check")
     Invoke-NativeChecked "validate public release manifests" "node" @("scripts/validate_public_release_manifests.mjs")
+    Invoke-NativeChecked "validate public release state" "node" @("scripts/validate_public_release_state.mjs")
     Invoke-NativeChecked "INSTNCT static audit" "node" @("scripts/audit_instnct_static_site.mjs")
     Invoke-NativeChecked "INSTNCT notify Worker audit" "node" @("scripts/audit_instnct_notify_worker.mjs")
     Invoke-NativeChecked "public surface audit" "python" @("scripts/audit_public_surface.py")

--- a/scripts/validate_public_release_state.mjs
+++ b/scripts/validate_public_release_state.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const VERSION_PATH = "docs/VERSION.json";
+const VERSION_SCHEMA = "vraxion.public.version.v1";
+const RELEASE_SLUG_RE = /^public-sdk-p[0-9]+-[0-9]{8}$/;
+const DATE_RE = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/;
+const SIMPLE_VERSION_RE = /^[a-z0-9][a-z0-9._-]*$/;
+const PAGES_URL = "https://vraxion.github.io/VRAXION/";
+
+const REQUIRED_VERSION_KEYS = [
+  "schema",
+  "status",
+  "date",
+  "public_surface",
+  "pages_surface",
+  "latest_public_release",
+  "home_asset_version",
+  "instnct_asset_version",
+  "anchorcell_asset_version",
+  "delivery_direction",
+  "crates",
+];
+const REQUIRED_RELEASE_REFERENCES = [
+  "README.md",
+  "PUBLIC_GITHUB_STATE.md",
+  "docs/CURRENT_STATUS.md",
+  "docs/CURRENT_CAPABILITIES.md",
+  "docs/index.html",
+];
+const REQUIRED_PUBLIC_STATE_MARKERS = [
+  "default branch: `main`",
+  "version record: `docs/VERSION.json`",
+  `Pages URL: \`${PAGES_URL}\``,
+  "gh release list --limit 20",
+  "node scripts\\validate_public_release_state.mjs",
+];
+
+const failures = [];
+
+function fail(message) {
+  failures.push(message);
+}
+
+function readText(relativePath) {
+  return fs.readFileSync(path.join(ROOT, relativePath), "utf8");
+}
+
+function readJson(relativePath) {
+  try {
+    return JSON.parse(readText(relativePath));
+  } catch (error) {
+    fail(`${relativePath}: invalid JSON: ${error.message}`);
+    return null;
+  }
+}
+
+function assertPlainObject(label, value) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${label}: must be an object`);
+    return false;
+  }
+  return true;
+}
+
+function assertRealDate(label, value) {
+  if (typeof value !== "string" || !DATE_RE.test(value)) {
+    fail(`${label}: invalid date string: ${value}`);
+    return;
+  }
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== value) {
+    fail(`${label}: not a real calendar date: ${value}`);
+  }
+}
+
+function assertSimpleField(label, value) {
+  if (typeof value !== "string" || !SIMPLE_VERSION_RE.test(value)) {
+    fail(`${label}: must be a non-empty simple identifier`);
+  }
+}
+
+function validateVersionRecord(version) {
+  if (!assertPlainObject(VERSION_PATH, version)) {
+    return null;
+  }
+  const expected = new Set(REQUIRED_VERSION_KEYS);
+  for (const key of Object.keys(version)) {
+    if (!expected.has(key)) {
+      fail(`${VERSION_PATH}: unsupported key: ${key}`);
+    }
+  }
+  for (const key of REQUIRED_VERSION_KEYS) {
+    if (!(key in version)) {
+      fail(`${VERSION_PATH}: missing required key: ${key}`);
+    }
+  }
+
+  if (version.schema !== VERSION_SCHEMA) {
+    fail(`${VERSION_PATH}: schema must be ${VERSION_SCHEMA}`);
+  }
+  assertSimpleField(`${VERSION_PATH}: status`, version.status);
+  assertRealDate(`${VERSION_PATH}: date`, version.date);
+  assertSimpleField(`${VERSION_PATH}: public_surface`, version.public_surface);
+  assertSimpleField(`${VERSION_PATH}: pages_surface`, version.pages_surface);
+  assertSimpleField(`${VERSION_PATH}: home_asset_version`, version.home_asset_version);
+  assertSimpleField(`${VERSION_PATH}: instnct_asset_version`, version.instnct_asset_version);
+  assertSimpleField(`${VERSION_PATH}: anchorcell_asset_version`, version.anchorcell_asset_version);
+  assertSimpleField(`${VERSION_PATH}: delivery_direction`, version.delivery_direction);
+
+  if (typeof version.latest_public_release !== "string" || !RELEASE_SLUG_RE.test(version.latest_public_release)) {
+    fail(`${VERSION_PATH}: latest_public_release is invalid: ${version.latest_public_release}`);
+  }
+
+  if (!Array.isArray(version.crates) || version.crates.length === 0) {
+    fail(`${VERSION_PATH}: crates must be a non-empty array`);
+  } else {
+    const crateSet = new Set();
+    for (const crateName of version.crates) {
+      if (typeof crateName !== "string" || !/^[a-z0-9][a-z0-9-]*$/.test(crateName)) {
+        fail(`${VERSION_PATH}: invalid crate name: ${crateName}`);
+      }
+      if (crateSet.has(crateName)) {
+        fail(`${VERSION_PATH}: duplicate crate name: ${crateName}`);
+      }
+      crateSet.add(crateName);
+    }
+    const crateDirs = fs
+      .readdirSync(path.join(ROOT, "crates"), { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort();
+    const listedCrates = [...crateSet].sort();
+    if (JSON.stringify(crateDirs) !== JSON.stringify(listedCrates)) {
+      fail(`${VERSION_PATH}: crates ${listedCrates.join(", ")} do not match crates/ directories ${crateDirs.join(", ")}`);
+    }
+    for (const crateName of listedCrates) {
+      const crateManifest = `crates/${crateName}/Cargo.toml`;
+      if (!fs.existsSync(path.join(ROOT, crateManifest))) {
+        fail(`${VERSION_PATH}: listed crate is missing Cargo.toml: ${crateManifest}`);
+      }
+    }
+  }
+
+  return version.latest_public_release;
+}
+
+function validateReleaseReferences(latestPublicRelease) {
+  if (!latestPublicRelease || !RELEASE_SLUG_RE.test(latestPublicRelease)) {
+    return;
+  }
+  const releaseUrl = `https://github.com/VRAXION/VRAXION/releases/tag/${latestPublicRelease}`;
+
+  for (const relativePath of REQUIRED_RELEASE_REFERENCES) {
+    const text = readText(relativePath);
+    if (!text.includes(latestPublicRelease)) {
+      fail(`${relativePath}: missing latest public release slug ${latestPublicRelease}`);
+    }
+    if (!text.includes(releaseUrl)) {
+      fail(`${relativePath}: missing latest public release URL ${releaseUrl}`);
+    }
+  }
+
+  const publicState = readText("PUBLIC_GITHUB_STATE.md");
+  for (const marker of REQUIRED_PUBLIC_STATE_MARKERS) {
+    if (!publicState.includes(marker)) {
+      fail(`PUBLIC_GITHUB_STATE.md: missing public-state marker: ${marker}`);
+    }
+  }
+
+  const indexHtml = readText("docs/index.html");
+  if (!indexHtml.includes(`<strong>${latestPublicRelease}</strong>`)) {
+    fail("docs/index.html: current artifact chip does not render the latest public release slug");
+  }
+}
+
+const version = readJson(VERSION_PATH);
+const latestPublicRelease = validateVersionRecord(version);
+validateReleaseReferences(latestPublicRelease);
+
+console.log("PUBLIC_RELEASE_STATE_VALIDATION");
+console.log(`latest_public_release=${latestPublicRelease || "unknown"}`);
+console.log(`failure_count=${failures.length}`);
+for (const failure of failures) {
+  console.log(`failure: ${failure}`);
+}
+if (failures.length > 0) {
+  process.exit(1);
+}
+console.log("public_release_state_validation=pass");


### PR DESCRIPTION
## What changed

- Added `scripts/validate_public_release_state.mjs` to validate the public version record and latest-release references across README, `PUBLIC_GITHUB_STATE.md`, status docs, capability docs, and Pages HTML.
- Wired the validator into CI, public surface audit, the export guard, PR template, release checklist, README, and changelog.
- Added the new state validator to the public GitHub pre-release check list.

## Why

The repo now has a manifest validator, but release readiness also depends on the public source-of-truth files pointing to the same current release. This adds a stable offline guard so the public version record, release URL, status copy, and crate list do not drift.

## Validation

- `node --check scripts\validate_public_release_state.mjs`
- `node scripts\validate_public_release_state.mjs`
- `node scripts\validate_public_release_manifests.mjs`
- `node scripts\sync_public_release_links.mjs --check`
- `python scripts\audit_public_surface.py`
- `git diff --cached --check`
- `powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1`