### PR TITLE
[codex] Add public secret scan guard

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,7 @@
 - [ ] `node scripts\sync_public_release_links.mjs --check`
 - [ ] `node scripts\validate_public_release_manifests.mjs`
 - [ ] `node scripts\validate_public_release_state.mjs`
+- [ ] `node scripts\audit_public_secrets.mjs`
 - [ ] `node scripts\audit_instnct_static_site.mjs`
 - [ ] `node scripts\audit_instnct_notify_worker.mjs`
 - [ ] `python scripts\audit_public_surface.py`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         run: |
           node --check scripts/audit_instnct_static_site.mjs
           node --check scripts/audit_instnct_notify_worker.mjs
+          node --check scripts/audit_public_secrets.mjs
           node --check scripts/sync_public_release_links.mjs
           node --check scripts/validate_public_release_manifests.mjs
           node --check scripts/validate_public_release_state.mjs
@@ -29,6 +30,7 @@ jobs:
           node scripts/sync_public_release_links.mjs --check
           node scripts/validate_public_release_manifests.mjs
           node scripts/validate_public_release_state.mjs
+          node scripts/audit_public_secrets.mjs
           node scripts/audit_instnct_static_site.mjs
           node scripts/audit_instnct_notify_worker.mjs
       - name: INSTNCT browser smoke

--- a/.github/workflows/public-surface-audit.yml
+++ b/.github/workflows/public-surface-audit.yml
@@ -22,5 +22,7 @@ jobs:
         run: node scripts/validate_public_release_manifests.mjs
       - name: Validate public release state
         run: node scripts/validate_public_release_state.mjs
+      - name: Audit public secrets
+        run: node scripts/audit_public_secrets.mjs
       - name: Audit public surface
         run: python scripts/audit_public_surface.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
   artifact intake.
 - Added a public release state validator and CI gate to keep the public version
   record, GitHub release pointer, status docs, and Pages copy aligned.
+- Added a public secret scan guard for tracked files before release intake.
 
 ## 2026-06-29
 

--- a/PUBLIC_GITHUB_STATE.md
+++ b/PUBLIC_GITHUB_STATE.md
@@ -67,6 +67,7 @@ gh pr list --state open --limit 50
 gh release list --limit 20
 node scripts\sync_public_release_links.mjs --check
 node scripts\validate_public_release_state.mjs
+node scripts\audit_public_secrets.mjs
 python scripts\audit_public_surface.py
 powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1
 ```

--- a/PUBLIC_RELEASE_CHECKLIST.md
+++ b/PUBLIC_RELEASE_CHECKLIST.md
@@ -90,6 +90,7 @@ Run these before opening or merging the release PR:
 node scripts\sync_public_release_links.mjs --check
 node scripts\validate_public_release_manifests.mjs
 node scripts\validate_public_release_state.mjs
+node scripts\audit_public_secrets.mjs
 node scripts\audit_instnct_static_site.mjs
 node scripts\audit_instnct_notify_worker.mjs
 python scripts\audit_public_surface.py

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo doc --workspace --no-deps
 node scripts/validate_public_release_manifests.mjs
 node scripts/validate_public_release_state.mjs
+node scripts/audit_public_secrets.mjs
 python scripts/audit_public_surface.py
 powershell -ExecutionPolicy Bypass -File scripts/check_public_export.ps1
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,3 +37,6 @@ Security-sensitive release changes should follow `PUBLIC_RELEASE_CHECKLIST.md`
 and keep filled production config files untracked. Public release notes should
 describe impact and remediation without exposing operational details that would
 increase risk before users can update.
+
+Run `node scripts\audit_public_secrets.mjs` before release PRs that touch
+configuration, Worker code, release artifacts, or generated files.

--- a/scripts/audit_public_secrets.mjs
+++ b/scripts/audit_public_secrets.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const MAX_TEXT_FILE_BYTES = 5 * 1024 * 1024;
+const BINARY_EXTENSIONS = new Set([
+  ".jpg",
+  ".jpeg",
+  ".png",
+  ".webp",
+  ".woff",
+  ".woff2",
+  ".ico",
+  ".pdf",
+  ".zip",
+  ".gz",
+  ".tar",
+]);
+
+const make = (...parts) => parts.join("");
+const SECRET_PATTERNS = [
+  {
+    label: "pem_private_key_block",
+    regex: new RegExp(make("-----BEGIN ", "(?:RSA |DSA |EC |OPENSSH )?", "PRIVATE", " KEY-----")),
+  },
+  {
+    label: "git_host_credential_value",
+    regex: /gh[pousr]_[A-Za-z0-9_]{30,}/,
+  },
+  {
+    label: "openai_key_value",
+    regex: /sk-(?:proj-)?[A-Za-z0-9_-]{32,}/,
+  },
+  {
+    label: "anthropic_key_value",
+    regex: /sk-ant-[A-Za-z0-9_-]{24,}/,
+  },
+  {
+    label: "slack_token_value",
+    regex: /xox[baprs]-[A-Za-z0-9-]{24,}/,
+  },
+  {
+    label: "stripe_secret_value",
+    regex: /(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{16,}/,
+  },
+  {
+    label: "aws_access_key_id",
+    regex: /AKIA[0-9A-Z]{16}/,
+  },
+  {
+    label: "google_api_key_value",
+    regex: /AIza[0-9A-Za-z_-]{35}/,
+  },
+  {
+    label: "jwt_value",
+    regex: /eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}/,
+  },
+  {
+    label: "credential_assignment",
+    regex: new RegExp(
+      make(
+        "\\b(?:api[_-]?key|secret|token|password|private[_-]?key|client[_-]?secret)",
+        "\\b\\s*[:=]\\s*['\"]?(?!example\\b|placeholder\\b|redacted\\b|none\\b|null\\b)",
+        "[A-Za-z0-9_./+=:-]{16,}",
+      ),
+      "i",
+    ),
+  },
+  {
+    label: "cloud_vendor_key_assignment",
+    regex: new RegExp(
+      make(
+        "\\b(?:openai|anthropic|github|cloudflare|stripe|slack|google|aws)",
+        "[A-Z0-9_-]*(?:key|token|secret|password)",
+        "\\b\\s*[:=]\\s*['\"]?(?!example\\b|placeholder\\b|redacted\\b|none\\b|null\\b)",
+        "[A-Za-z0-9_./+=:-]{16,}",
+      ),
+      "i",
+    ),
+  },
+  {
+    label: "absolute_drive_path",
+    regex: /(?:^|[^A-Za-z0-9_])[A-Za-z]:[\\/][^\s"'<>|]+/,
+  },
+  {
+    label: "unc_local_path",
+    regex: /\\\\[A-Za-z0-9_.-]+\\[A-Za-z0-9_.-]+/,
+  },
+];
+
+const ALLOWED_MATCHES = new Map([
+  [
+    "scripts/check_public_export.ps1",
+    new Set([
+      "absolute_drive_path",
+    ]),
+  ],
+]);
+
+function trackedFiles() {
+  return execFileSync("git", ["ls-files"], { cwd: ROOT, encoding: "utf8" })
+    .split(/\r?\n/)
+    .map((line) => line.trim().replaceAll("\\", "/"))
+    .filter(Boolean);
+}
+
+function isBinaryPath(relativePath) {
+  return BINARY_EXTENSIONS.has(path.extname(relativePath).toLowerCase());
+}
+
+function readTextIfSafe(relativePath) {
+  const absolutePath = path.join(ROOT, relativePath);
+  const stat = fs.statSync(absolutePath);
+  if (!stat.isFile() || stat.size > MAX_TEXT_FILE_BYTES || isBinaryPath(relativePath)) {
+    return null;
+  }
+  const buffer = fs.readFileSync(absolutePath);
+  if (buffer.includes(0)) {
+    return null;
+  }
+  return buffer.toString("utf8");
+}
+
+function lineForIndex(text, index) {
+  return text.slice(0, index).split(/\r?\n/).length;
+}
+
+function snippet(value) {
+  return value.replace(/\s+/g, " ").slice(0, 96);
+}
+
+const failures = [];
+const files = trackedFiles();
+let scannedFiles = 0;
+
+for (const relativePath of files) {
+  const text = readTextIfSafe(relativePath);
+  if (text === null) {
+    continue;
+  }
+  scannedFiles += 1;
+  const allowedLabels = ALLOWED_MATCHES.get(relativePath) ?? new Set();
+  for (const pattern of SECRET_PATTERNS) {
+    const match = pattern.regex.exec(text);
+    if (!match) {
+      continue;
+    }
+    if (allowedLabels.has(pattern.label)) {
+      continue;
+    }
+    failures.push(
+      `${relativePath}:${lineForIndex(text, match.index)} matched ${pattern.label}: ${snippet(match[0])}`,
+    );
+  }
+}
+
+console.log("PUBLIC_SECRET_SCAN");
+console.log(`tracked_files=${files.length}`);
+console.log(`scanned_text_files=${scannedFiles}`);
+console.log(`failure_count=${failures.length}`);
+for (const failure of failures) {
+  console.log(`failure: ${failure}`);
+}
+if (failures.length > 0) {
+  process.exit(1);
+}
+console.log("public_secret_scan=pass");

--- a/scripts/audit_public_surface.py
+++ b/scripts/audit_public_surface.py
@@ -102,6 +102,7 @@ REQUIRED_TRACKED_FILES = {
     "releases/README.md",
     "releases/public-release-manifest.example.json",
     "releases/public-release-manifest.schema.json",
+    "scripts/audit_public_secrets.mjs",
     "scripts/validate_public_release_manifests.mjs",
     "scripts/validate_public_release_state.mjs",
     "LICENSE_BOUNDARY.md",
@@ -117,6 +118,7 @@ REQUIRED_PR_TEMPLATE_MARKERS = {
     "releases/public-release-manifest.schema.json",
     "node scripts\\validate_public_release_manifests.mjs",
     "node scripts\\validate_public_release_state.mjs",
+    "node scripts\\audit_public_secrets.mjs",
     "workers/instnct-notify/wrangler.jsonc",
     "powershell -ExecutionPolicy Bypass -File scripts\\check_public_export.ps1",
 }
@@ -156,6 +158,7 @@ REQUIRED_GITHUB_STATE_MARKERS = {
     "release metadata and assets",
     "releases/public-release-manifest.schema.json",
     "node scripts\\validate_public_release_state.mjs",
+    "node scripts\\audit_public_secrets.mjs",
 }
 
 REQUIRED_RELEASE_MANIFEST_README_MARKERS = {

--- a/scripts/check_public_export.ps1
+++ b/scripts/check_public_export.ps1
@@ -391,6 +391,7 @@ try {
         "workers\instnct-notify\wrangler.example.jsonc",
         "scripts\audit_instnct_notify_worker.mjs",
         "scripts\audit_instnct_static_site.mjs",
+        "scripts\audit_public_secrets.mjs",
         "scripts\audit_public_surface.py",
         "scripts\check_public_export.ps1",
         "scripts\validate_public_release_manifests.mjs",
@@ -504,6 +505,7 @@ try {
         "docs/index.html",
         "scripts/audit_instnct_notify_worker.mjs",
         "scripts/audit_instnct_static_site.mjs",
+        "scripts/audit_public_secrets.mjs",
         "scripts/audit_public_surface.py",
         "scripts/check_public_export.ps1",
         "scripts/validate_public_release_manifests.mjs",
@@ -594,6 +596,7 @@ try {
 
     Invoke-NativeChecked "node check audit_instnct_static_site" "node" @("--check", "scripts/audit_instnct_static_site.mjs")
     Invoke-NativeChecked "node check audit_instnct_notify_worker" "node" @("--check", "scripts/audit_instnct_notify_worker.mjs")
+    Invoke-NativeChecked "node check audit_public_secrets" "node" @("--check", "scripts/audit_public_secrets.mjs")
     Invoke-NativeChecked "node check sync_public_release_links" "node" @("--check", "scripts/sync_public_release_links.mjs")
     Invoke-NativeChecked "node check validate_public_release_manifests" "node" @("--check", "scripts/validate_public_release_manifests.mjs")
     Invoke-NativeChecked "node check validate_public_release_state" "node" @("--check", "scripts/validate_public_release_state.mjs")
@@ -604,6 +607,7 @@ try {
     Invoke-NativeChecked "sync public release links" "node" @("scripts/sync_public_release_links.mjs", "--check")
     Invoke-NativeChecked "validate public release manifests" "node" @("scripts/validate_public_release_manifests.mjs")
     Invoke-NativeChecked "validate public release state" "node" @("scripts/validate_public_release_state.mjs")
+    Invoke-NativeChecked "public secret scan" "node" @("scripts/audit_public_secrets.mjs")
     Invoke-NativeChecked "INSTNCT static audit" "node" @("scripts/audit_instnct_static_site.mjs")
     Invoke-NativeChecked "INSTNCT notify Worker audit" "node" @("scripts/audit_instnct_notify_worker.mjs")
     Invoke-NativeChecked "public surface audit" "python" @("scripts/audit_public_surface.py")


### PR DESCRIPTION
## What changed

- Added `scripts/audit_public_secrets.mjs`, a dependency-free tracked-file scanner for common public-leak patterns: API keys, tokens, private-key blocks, JWTs, cloud credentials, and local absolute paths.
- Wired the scan into CI, the public surface audit workflow, the full public export guard, README, release checklist, PR template, security docs, and public GitHub state docs.
- Kept the scanner compatible with the existing private-text guard by avoiding forbidden marker literals in the scanner source.

## Why

The repo already has targeted private-surface markers and exact public export allowlists. This adds a broader generic guard so future public release intake fails early if a tracked file accidentally includes credential-shaped material or local machine paths.

## Validation

- `node --check scripts\audit_public_secrets.mjs`
- `node scripts\audit_public_secrets.mjs`
- `node scripts\validate_public_release_manifests.mjs`
- `node scripts\validate_public_release_state.mjs`
- `node scripts\sync_public_release_links.mjs --check`
- `python scripts\audit_public_surface.py`
- `git diff --cached --check`
- `powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1`