### PR TITLE
[codex] Require full public guard commands in release manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 - Added a public release state validator and CI gate to keep the public version
   record, GitHub release pointer, status docs, and Pages copy aligned.
 - Added a public secret scan guard for tracked files before release intake.
+- Required release manifests to list the full public guard command set,
+  including release-state validation and secret scanning.
 
 ## 2026-06-29
 

--- a/releases/README.md
+++ b/releases/README.md
@@ -15,6 +15,8 @@ Validate manifests before review:
 
 ```powershell
 node scripts\validate_public_release_manifests.mjs
+node scripts\validate_public_release_state.mjs
+node scripts\audit_public_secrets.mjs
 ```
 
 Do not include:

--- a/releases/public-release-manifest.example.json
+++ b/releases/public-release-manifest.example.json
@@ -37,6 +37,8 @@
     "commands": [
       "node scripts\\sync_public_release_links.mjs --check",
       "node scripts\\validate_public_release_manifests.mjs",
+      "node scripts\\validate_public_release_state.mjs",
+      "node scripts\\audit_public_secrets.mjs",
       "python scripts\\audit_public_surface.py",
       "powershell -ExecutionPolicy Bypass -File scripts\\check_public_export.ps1"
     ],

--- a/scripts/audit_public_surface.py
+++ b/scripts/audit_public_surface.py
@@ -468,6 +468,15 @@ def main() -> int:
         for command in commands
     ):
         failures.append("release manifest example must include the release manifest validator command")
+    if not isinstance(commands, list) or not any(
+        "scripts\\validate_public_release_state.mjs" in command
+        for command in commands
+    ):
+        failures.append("release manifest example must include the release state validator command")
+    if not isinstance(commands, list) or not any(
+        "scripts\\audit_public_secrets.mjs" in command for command in commands
+    ):
+        failures.append("release manifest example must include the public secret scan command")
 
     index_html = read_text(ROOT / "docs" / "index.html")
     expected_release_url = "https://github.com/VRAXION/VRAXION/releases/tag/" + str(

--- a/scripts/validate_public_release_manifests.mjs
+++ b/scripts/validate_public_release_manifests.mjs
@@ -45,6 +45,8 @@ const REQUIRED_EXCLUSIONS = [
 const REQUIRED_COMMANDS = [
   "node scripts\\sync_public_release_links.mjs --check",
   "node scripts\\validate_public_release_manifests.mjs",
+  "node scripts\\validate_public_release_state.mjs",
+  "node scripts\\audit_public_secrets.mjs",
   "python scripts\\audit_public_surface.py",
   "powershell -ExecutionPolicy Bypass -File scripts\\check_public_export.ps1",
 ];


### PR DESCRIPTION
## What changed

- Required release manifest `verification.commands` to include the full current public guard set: release-link sync, manifest validator, release-state validator, public secret scan, public surface audit, and full export guard.
- Updated `public-release-manifest.example.json` and `releases/README.md` so future release manifests copy the stricter command list.
- Added matching Python audit checks so the public surface audit also fails if the example manifest drifts.

## Why

The public repo now has separate state and secret guards, but the manifest validator still accepted manifests that did not list those guards. This closes that mismatch so future release intake has one explicit, complete verification contract.

## Validation

- `node scripts\validate_public_release_manifests.mjs`
- `python scripts\audit_public_surface.py`
- `node scripts\audit_public_secrets.mjs`
- `node scripts\sync_public_release_links.mjs --check`
- `git diff --cached --check`
- `powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1`