### PR TITLE
[codex] Lock public workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   static-site:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-instnct-notify.yml
+++ b/.github/workflows/deploy-instnct-notify.yml
@@ -3,6 +3,9 @@ name: Deploy INSTNCT Notify Worker
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/public-pages-smoke.yml
+++ b/.github/workflows/public-pages-smoke.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "17 4 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   live-links:
     runs-on: ubuntu-latest

--- a/.github/workflows/public-surface-audit.yml
+++ b/.github/workflows/public-surface-audit.yml
@@ -7,6 +7,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   audit:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 - Added a public secret scan guard for tracked files before release intake.
 - Required release manifests to list the full public guard command set,
   including release-state validation and secret scanning.
+- Locked public GitHub Actions workflows to read-only repository permissions
+  and added audit coverage for workflow permission drift.
 
 ## 2026-06-29
 

--- a/scripts/audit_public_surface.py
+++ b/scripts/audit_public_surface.py
@@ -206,6 +206,29 @@ REQUIRED_SUPPORT_MARKERS = {
     "raw operator output",
 }
 
+REQUIRED_WORKFLOW_PERMISSION_MARKERS = {
+    ".github/workflows/ci.yml": "permissions:\n  contents: read",
+    ".github/workflows/deploy-instnct-notify.yml": "permissions:\n  contents: read",
+    ".github/workflows/public-pages-smoke.yml": "permissions:\n  contents: read",
+    ".github/workflows/public-surface-audit.yml": "permissions:\n  contents: read",
+}
+
+FORBIDDEN_WORKFLOW_PERMISSION_MARKERS = {
+    "actions: write",
+    "checks: write",
+    "contents: write",
+    "deployments: write",
+    "discussions: write",
+    "id-token: write",
+    "issues: write",
+    "packages: write",
+    "pages: write",
+    "pull-requests: write",
+    "repository-projects: write",
+    "security-events: write",
+    "statuses: write",
+}
+
 REQUIRED_GITATTRIBUTES_ENTRIES = {
     "* text=auto eol=lf",
     "*.jpg binary",
@@ -336,6 +359,17 @@ def main() -> int:
     for required in sorted(REQUIRED_SUPPORT_MARKERS):
         if required not in support_doc:
             failures.append(f"support doc missing public-support marker: {required}")
+
+    for relative_path, required in sorted(REQUIRED_WORKFLOW_PERMISSION_MARKERS.items()):
+        workflow_text = read_text(ROOT / relative_path)
+        if required not in workflow_text:
+            failures.append(f"workflow missing read-only permission marker: {relative_path}")
+        workflow_lower = workflow_text.lower()
+        for forbidden in sorted(FORBIDDEN_WORKFLOW_PERMISSION_MARKERS):
+            if forbidden in workflow_lower:
+                failures.append(
+                    f"workflow contains forbidden write permission {forbidden!r}: {relative_path}"
+                )
 
     release_manifest_readme = read_text(ROOT / "releases" / "README.md")
     for required in sorted(REQUIRED_RELEASE_MANIFEST_README_MARKERS):


### PR DESCRIPTION
## What changed

- Added explicit `permissions: contents: read` to every public GitHub Actions workflow.
- Extended `scripts/audit_public_surface.py` to require the read-only permission block and reject common write-scope workflow permissions.
- Updated the changelog with the workflow permission hardening note.

## Why

The public workflows only need repository read access. Making that explicit prevents accidental expansion if repository defaults change and gives the public audit a concrete guard against workflow permission drift.

## Validation

- `python scripts\audit_public_surface.py`
- `node scripts\audit_public_secrets.mjs`
- `node scripts\validate_public_release_manifests.mjs`
- `node scripts\validate_public_release_state.mjs`
- `node scripts\sync_public_release_links.mjs --check`
- `git diff --cached --check`
- `powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1`