### PR TITLE
[codex] Audit public Pages state before release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
   and added audit coverage for workflow permission drift.
 - Added a live public GitHub state audit for pre-release checks against open
   pull requests, remote branches, default branch, and the latest GitHub release.
+- Extended public release verification to require live Pages source, build,
+  URL, and `VERSION.json` checks before release publication.
 
 ## 2026-06-29
 

--- a/PUBLIC_GITHUB_STATE.md
+++ b/PUBLIC_GITHUB_STATE.md
@@ -33,6 +33,7 @@ Before creating or updating a public release, review:
 - CODEOWNERS routing for public boundary, release, workflow, and docs changes
 - Dependabot or dependency-update PRs that may affect the public build
 - Pages deployment target
+- latest Pages build status and live `VERSION.json`
 - public status docs and release links
 - public release manifest entries under `releases/`, when artifacts or claims
   change
@@ -67,17 +68,21 @@ gh pr list --state open --limit 50
 gh release list --limit 20
 node scripts\audit_public_github_state.mjs
 node scripts\sync_public_release_links.mjs --check
+node scripts\validate_public_release_manifests.mjs
 node scripts\validate_public_release_state.mjs
 node scripts\audit_public_secrets.mjs
 python scripts\audit_public_surface.py
+node scripts\smoke_public_pages_links.mjs
 powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1
 ```
 
 Run `node scripts\audit_public_github_state.mjs` before opening the final
 release PR, and run it again after merge before publishing or marking a GitHub
 release as current. The live audit intentionally fails when open pull requests
-or extra remote branches are present, because the public release state should be
-settled before it becomes the current public truth.
+or extra remote branches are present, or when the GitHub Pages source, latest
+Pages build, live Pages URL, or live `VERSION.json` do not match the reviewed
+public state. The public release state should be settled before it becomes the
+current public truth.
 
 The public release PR should state which GitHub release, tag, status doc,
 manifest, and artifact entry are the source of truth.

--- a/PUBLIC_RELEASE_CHECKLIST.md
+++ b/PUBLIC_RELEASE_CHECKLIST.md
@@ -103,7 +103,8 @@ powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1
 Run the live GitHub state audit before opening the final release PR, and run it
 again after merge before publishing or marking a GitHub release as current. It
 checks that the public repository, default branch, open pull requests, remote
-branches, and latest GitHub release agree with `docs/VERSION.json`.
+branches, latest GitHub release, Pages source, latest Pages build, and live
+`VERSION.json` agree with `docs/VERSION.json`.
 
 For Worker changes, also run the notify live smoke against the intended target
 environment before enabling any public form path.

--- a/releases/README.md
+++ b/releases/README.md
@@ -14,9 +14,14 @@ public files, public URLs, public checks, and public artifact metadata.
 Validate manifests before review:
 
 ```powershell
+node scripts\audit_public_github_state.mjs
+node scripts\sync_public_release_links.mjs --check
 node scripts\validate_public_release_manifests.mjs
 node scripts\validate_public_release_state.mjs
 node scripts\audit_public_secrets.mjs
+python scripts\audit_public_surface.py
+node scripts\smoke_public_pages_links.mjs
+powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1
 ```
 
 Do not include:

--- a/releases/public-release-manifest.example.json
+++ b/releases/public-release-manifest.example.json
@@ -35,11 +35,13 @@
   },
   "verification": {
     "commands": [
+      "node scripts\\audit_public_github_state.mjs",
       "node scripts\\sync_public_release_links.mjs --check",
       "node scripts\\validate_public_release_manifests.mjs",
       "node scripts\\validate_public_release_state.mjs",
       "node scripts\\audit_public_secrets.mjs",
       "python scripts\\audit_public_surface.py",
+      "node scripts\\smoke_public_pages_links.mjs",
       "powershell -ExecutionPolicy Bypass -File scripts\\check_public_export.ps1"
     ],
     "github_checks": [

--- a/scripts/audit_public_github_state.mjs
+++ b/scripts/audit_public_github_state.mjs
@@ -8,11 +8,17 @@ const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const VERSION_PATH = "docs/VERSION.json";
 const EXPECTED_REPOSITORY = "VRAXION/VRAXION";
 const EXPECTED_DEFAULT_BRANCH = "main";
+const EXPECTED_PAGES_URL = "https://vraxion.github.io/VRAXION/";
+const EXPECTED_PAGES_SOURCE_BRANCH = "main";
+const EXPECTED_PAGES_SOURCE_PATH = "/docs";
 const ALLOWED_REMOTE_BRANCHES = new Set(["origin", "origin/HEAD", "origin/main"]);
+const PUBLIC_URL_TIMEOUT_MS = 20000;
 const args = new Set(process.argv.slice(2));
 
 if (args.has("--help")) {
-  console.log("Usage: node scripts/audit_public_github_state.mjs [--allow-open-prs] [--allow-extra-remote-branches]");
+  console.log(
+    "Usage: node scripts/audit_public_github_state.mjs [--allow-open-prs] [--allow-extra-remote-branches]",
+  );
   process.exit(0);
 }
 
@@ -62,6 +68,52 @@ function readJsonFile(relativePath) {
   } catch (error) {
     fail(`${relativePath}: invalid JSON: ${error.message}`);
     return null;
+  }
+}
+
+function normalizeTrailingSlash(value) {
+  return value.endsWith("/") ? value : `${value}/`;
+}
+
+function getRemoteMainCommit() {
+  const output = runCommand("git remote main commit", "git", ["ls-remote", "origin", "refs/heads/main"]);
+  const commit = output?.split(/\s+/)[0] || "";
+  if (!/^[a-f0-9]{40}$/i.test(commit)) {
+    fail(`origin/main remote commit could not be resolved: ${commit || "missing"}`);
+    return "unknown";
+  }
+  return commit.toLowerCase();
+}
+
+async function fetchWithTimeout(url, options = {}) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PUBLIC_URL_TIMEOUT_MS);
+  try {
+    return await fetch(url, {
+      redirect: "follow",
+      ...options,
+      signal: controller.signal,
+      headers: {
+        "user-agent": "VRAXION public GitHub state audit",
+        ...(options.headers || {}),
+      },
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function fetchText(url, label) {
+  try {
+    const response = await fetchWithTimeout(url);
+    if (!response.ok) {
+      fail(`${label} returned HTTP ${response.status}: ${url}`);
+      return { status: response.status, text: "" };
+    }
+    return { status: response.status, text: await response.text() };
+  } catch (error) {
+    fail(`${label} could not be fetched: ${url} ${error.message}`);
+    return { status: "error", text: "" };
   }
 }
 
@@ -203,19 +255,105 @@ function validateRelease(version) {
   return { latestPublicRelease, latestReleaseTag };
 }
 
+async function validatePagesState(version, remoteMainCommit) {
+  const pages = runJson("GitHub Pages config", "gh", ["api", `repos/${EXPECTED_REPOSITORY}/pages`]);
+  const latestBuild = runJson("GitHub Pages latest build", "gh", [
+    "api",
+    `repos/${EXPECTED_REPOSITORY}/pages/builds/latest`,
+  ]);
+  let pagesStatus = pages?.status || "unknown";
+  let pagesBuildStatus = latestBuild?.status || "unknown";
+  let pagesBuildCommit = latestBuild?.commit || "unknown";
+  let publicPagesHttpStatus = "unknown";
+  let liveVersionRelease = "unknown";
+
+  if (pages !== null) {
+    const pagesUrl = normalizeTrailingSlash(String(pages.html_url || ""));
+    if (pagesUrl !== EXPECTED_PAGES_URL) {
+      fail(`GitHub Pages URL must be ${EXPECTED_PAGES_URL}, got ${pages.html_url || "missing"}`);
+    }
+    if (pages.status !== "built") {
+      fail(`GitHub Pages status must be built, got ${pages.status || "missing"}`);
+    }
+    if (pages.public !== true) {
+      fail("GitHub Pages must be public");
+    }
+    if (pages.https_enforced !== true) {
+      fail("GitHub Pages must enforce HTTPS");
+    }
+    if (pages.source?.branch !== EXPECTED_PAGES_SOURCE_BRANCH || pages.source?.path !== EXPECTED_PAGES_SOURCE_PATH) {
+      fail(
+        `GitHub Pages source must be ${EXPECTED_PAGES_SOURCE_BRANCH}:${EXPECTED_PAGES_SOURCE_PATH}, got ${
+          pages.source?.branch || "missing"
+        }:${pages.source?.path || "missing"}`,
+      );
+    }
+  }
+
+  if (latestBuild !== null) {
+    if (latestBuild.status !== "built") {
+      fail(`latest GitHub Pages build must be built, got ${latestBuild.status || "missing"}`);
+    }
+    if (latestBuild.error?.message) {
+      fail(`latest GitHub Pages build reports an error: ${latestBuild.error.message}`);
+    }
+    if (remoteMainCommit !== "unknown" && latestBuild.commit?.toLowerCase() !== remoteMainCommit) {
+      fail(`latest GitHub Pages build commit must match origin/main ${remoteMainCommit}, got ${latestBuild.commit}`);
+    }
+  }
+
+  const homeFetch = await fetchText(EXPECTED_PAGES_URL, "public Pages home");
+  publicPagesHttpStatus = String(homeFetch.status);
+  const versionFetch = await fetchText(`${EXPECTED_PAGES_URL}VERSION.json`, "public Pages VERSION.json");
+  if (versionFetch.text) {
+    try {
+      const liveVersion = JSON.parse(versionFetch.text);
+      liveVersionRelease = String(liveVersion.latest_public_release || "");
+      if (version?.latest_public_release && liveVersionRelease !== version.latest_public_release) {
+        fail(
+          `live Pages VERSION latest_public_release must be ${version.latest_public_release}, got ${
+            liveVersionRelease || "missing"
+          }`,
+        );
+      }
+      if (version?.date && liveVersion.date !== version.date) {
+        fail(`live Pages VERSION date must be ${version.date}, got ${liveVersion.date || "missing"}`);
+      }
+    } catch (error) {
+      fail(`public Pages VERSION.json is invalid JSON: ${error.message}`);
+    }
+  }
+
+  return {
+    pagesStatus,
+    pagesBuildStatus,
+    pagesBuildCommit,
+    publicPagesHttpStatus,
+    liveVersionRelease: liveVersionRelease || "unknown",
+  };
+}
+
 runCommand("GitHub auth status", "gh", ["auth", "status"]);
 validateOriginRemote();
 const remoteBranches = validateRemoteBranches();
+const remoteMainCommit = getRemoteMainCommit();
 const repository = validateRepository();
 const openPullRequests = validateOpenPullRequests();
 const version = readJsonFile(VERSION_PATH);
 const { latestPublicRelease, latestReleaseTag } = validateRelease(version);
+const pagesState = await validatePagesState(version, remoteMainCommit);
 
 console.log("PUBLIC_GITHUB_STATE_AUDIT");
 console.log(`repository=${repository?.nameWithOwner || "unknown"}`);
 console.log(`default_branch=${repository?.defaultBranchRef?.name || "unknown"}`);
+console.log(`origin_main_commit=${remoteMainCommit}`);
 console.log(`latest_public_release=${latestPublicRelease}`);
 console.log(`github_latest_release=${latestReleaseTag}`);
+console.log(`pages_status=${pagesState.pagesStatus}`);
+console.log(`pages_latest_build_status=${pagesState.pagesBuildStatus}`);
+console.log(`pages_latest_build_commit=${pagesState.pagesBuildCommit}`);
+console.log(`pages_live_version_release=${pagesState.liveVersionRelease}`);
+console.log(`public_pages_http_status=${pagesState.publicPagesHttpStatus}`);
 console.log(`open_pull_request_count=${openPullRequests.length}`);
 console.log(`remote_branch_count=${remoteBranches.length}`);
 console.log(`failure_count=${failures.length}`);

--- a/scripts/audit_public_surface.py
+++ b/scripts/audit_public_surface.py
@@ -156,6 +156,7 @@ REQUIRED_GITHUB_STATE_MARKERS = {
     "latest public release: `public-sdk-p11-20260629`",
     "non-public training data",
     "node scripts\\audit_public_github_state.mjs",
+    "latest Pages build",
     "public manifests and GitHub",
     "release metadata and assets",
     "releases/public-release-manifest.schema.json",
@@ -496,6 +497,10 @@ def main() -> int:
     verification = release_manifest_example.get("verification")
     commands = verification.get("commands") if isinstance(verification, dict) else None
     if not isinstance(commands, list) or not any(
+        "scripts\\audit_public_github_state.mjs" in command for command in commands
+    ):
+        failures.append("release manifest example must include the live GitHub state audit command")
+    if not isinstance(commands, list) or not any(
         "scripts\\check_public_export.ps1" in command for command in commands
     ):
         failures.append("release manifest example must include the public export guard command")
@@ -513,6 +518,10 @@ def main() -> int:
         "scripts\\audit_public_secrets.mjs" in command for command in commands
     ):
         failures.append("release manifest example must include the public secret scan command")
+    if not isinstance(commands, list) or not any(
+        "scripts\\smoke_public_pages_links.mjs" in command for command in commands
+    ):
+        failures.append("release manifest example must include the live public Pages smoke command")
 
     index_html = read_text(ROOT / "docs" / "index.html")
     expected_release_url = "https://github.com/VRAXION/VRAXION/releases/tag/" + str(

--- a/scripts/validate_public_release_manifests.mjs
+++ b/scripts/validate_public_release_manifests.mjs
@@ -43,11 +43,13 @@ const REQUIRED_EXCLUSIONS = [
   "private_dashboards",
 ];
 const REQUIRED_COMMANDS = [
+  "node scripts\\audit_public_github_state.mjs",
   "node scripts\\sync_public_release_links.mjs --check",
   "node scripts\\validate_public_release_manifests.mjs",
   "node scripts\\validate_public_release_state.mjs",
   "node scripts\\audit_public_secrets.mjs",
   "python scripts\\audit_public_surface.py",
+  "node scripts\\smoke_public_pages_links.mjs",
   "powershell -ExecutionPolicy Bypass -File scripts\\check_public_export.ps1",
 ];
 const REQUIRED_GITHUB_CHECKS = [


### PR DESCRIPTION
## Summary

- extend `scripts/audit_public_github_state.mjs` to verify GitHub Pages source, latest Pages build status, latest build commit, public URL reachability, and live `VERSION.json`
- require future release manifests to list the live GitHub state audit and live Pages smoke commands
- document the Pages state checks in the public GitHub state and release checklist docs

## Validation

- `node --check scripts/audit_public_github_state.mjs`
- `node scripts/audit_public_github_state.mjs` before opening this PR: Pages status `built`, latest Pages build `built`, latest build commit matched `origin/main`, live `VERSION.json` matched `docs/VERSION.json`, public URL HTTP `200`
- `node scripts/validate_public_release_manifests.mjs`
- `python scripts/audit_public_surface.py`
- `node scripts/audit_public_secrets.mjs`
- `node scripts/smoke_public_pages_links.mjs`
- `node scripts/validate_public_release_state.mjs`
- `node scripts/sync_public_release_links.mjs --check`
- `powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1`