### PR TITLE
[codex] Harden public local path guards

### DIFF
--- a/.github/ISSUE_TEMPLATE/public-surface-report.yml
+++ b/.github/ISSUE_TEMPLATE/public-surface-report.yml
@@ -7,7 +7,7 @@ body:
       value: |
         Use this form only for the visible public surface: docs, GitHub Pages, public crates, examples, release notes, and public workflow behavior.
 
-        Do not paste secrets, tokens, private code, non-public training data, raw operator output, local machine paths, production config, or private dashboards. If the report has security impact, use SECURITY.md instead of a public issue.
+        Do not paste secrets, tokens, private code, non-public training data, raw operator output, absolute local or UNC machine paths, production config, or private dashboards. If the report has security impact, use SECURITY.md instead of a public issue.
   - type: dropdown
     id: public_area
     attributes:
@@ -51,7 +51,7 @@ body:
     attributes:
       label: Public-safety confirmation
       options:
-        - label: I did not include secrets, tokens, private code, non-public training data, local machine paths, raw operator output, production config, or private dashboards.
+        - label: I did not include secrets, tokens, private code, non-public training data, absolute local or UNC machine paths, raw operator output, production config, or private dashboards.
           required: true
         - label: I will use SECURITY.md instead of a public issue if this has security impact.
           required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 
 ## Release Intake
 
-- [ ] This PR does not add private engine source, non-public training data, raw operator output, local paths, secrets, or filled production config.
+- [ ] This PR does not add private engine source, non-public training data, raw operator output, absolute local or UNC paths, secrets, or filled production config.
 - [ ] `PUBLIC_RELEASE_CHECKLIST.md` was followed, or this PR does not change release status, artifacts, downloads, or public claims.
 - [ ] Any generated local config, including `workers/instnct-notify/wrangler.jsonc`, remains untracked.
 - [ ] Any new artifact has public-safe provenance, naming, and checksum or signature material where applicable.

--- a/PUBLIC_RELEASE_CHECKLIST.md
+++ b/PUBLIC_RELEASE_CHECKLIST.md
@@ -2,8 +2,8 @@
 
 Use this checklist before adding any new public release material to this
 repository. The goal is simple: publish only reviewed public artifacts and keep
-private engine work, non-public training data, local paths, secrets, and raw
-operator output out of the public tree.
+private engine work, non-public training data, absolute local or UNC paths,
+secrets, and raw operator output out of the public tree.
 
 ## Intake Scope
 
@@ -49,7 +49,7 @@ The release PR must not include:
 - private engine source or internals
 - non-public training data
 - raw experiment logs or operator run output
-- local machine paths
+- absolute local or UNC machine paths
 - secrets, tokens, keys, or filled production config
 - private data adapters
 - skill persistence stores

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ Before any new public release is added, the release should have:
 3. a reviewed `releases/<release-slug>.manifest.json` when public artifacts,
    checksums, signatures, or status claims change
 4. an updated `docs/VERSION.json` and matching public page links
-5. no private engine code, private data, local paths, secrets, or internal run output
+5. no private engine code, private data, absolute local or UNC paths, secrets,
+   or internal run output
 6. green CI and a passing public export guard
 
 Use `PUBLIC_RELEASE_CHECKLIST.md` as the release PR checklist before adding a

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -15,9 +15,9 @@ workflow behavior, and public documentation.
 ## Do Not Include
 
 Do not put secrets, tokens, private code, internal implementation excerpts,
-non-public training data, raw operator output, local machine paths, production
-config, private dashboards, or credential values in public issues, pull
-requests, comments, or discussions.
+non-public training data, raw operator output, absolute local or UNC machine paths,
+production config, private dashboards, or credential values in public issues,
+pull requests, comments, or discussions.
 
 If a report needs private material to explain the impact, do not open a public
 issue. Use the security route or contact the repository owner profile instead.

--- a/scripts/audit_public_surface.py
+++ b/scripts/audit_public_surface.py
@@ -46,6 +46,17 @@ FORBIDDEN_TEXT = [
     marker("C:", "\\"),
 ]
 
+FORBIDDEN_TEXT_REGEX = [
+    (
+        "absolute_drive_path",
+        re.compile(r"(?:^|[^A-Za-z0-9_])[A-Za-z]:[\\/][^\s\"'<>|]+"),
+    ),
+    (
+        "unc_local_path",
+        re.compile(r"\\\\[A-Za-z0-9_.-]+\\[A-Za-z0-9_.-]+"),
+    ),
+]
+
 LEGAL_TEXT_FILES = {
     "LICENSE",
     "crates/alphasync-core/LICENSE",
@@ -116,6 +127,7 @@ REQUIRED_PR_TEMPLATE_MARKERS = {
     "What exactly becomes public?",
     "What stays private?",
     "PUBLIC_RELEASE_CHECKLIST.md",
+    "absolute local or UNC paths",
     "Release manifest checked:",
     "releases/public-release-manifest.schema.json",
     "node scripts\\validate_public_release_manifests.mjs",
@@ -188,9 +200,9 @@ REQUIRED_RELEASE_MANIFEST_EXCLUSIONS = {
 }
 
 REQUIRED_ISSUE_TEMPLATE_MARKERS = {
+    "absolute local or UNC machine paths",
     "Do not paste secrets",
     "SECURITY.md",
-    "local machine paths",
     "non-public training data",
     "public surface",
     "raw operator output",
@@ -210,6 +222,7 @@ REQUIRED_SUPPORT_MARKERS = {
     "non-public training data",
     "public files and public releases",
     "raw operator output",
+    "absolute local or UNC machine paths",
 }
 
 REQUIRED_WORKFLOW_PERMISSION_MARKERS = {
@@ -430,6 +443,12 @@ def main() -> int:
             for needle in FORBIDDEN_TEXT:
                 if needle in text:
                     failures.append(f"forbidden text marker {needle!r}: {relative}")
+            for label, pattern in FORBIDDEN_TEXT_REGEX:
+                match = pattern.search(text)
+                if match:
+                    failures.append(
+                        f"forbidden text regex {label!r}: {relative}"
+                    )
             if (
                 normalized not in LEGAL_TEXT_FILES
                 and normalized.endswith(PUBLIC_COPY_SUFFIXES)

--- a/scripts/check_public_export.ps1
+++ b/scripts/check_public_export.ps1
@@ -142,6 +142,7 @@ function Assert-NoTextPattern {
 
         $relative = $fileFullName.Substring($scanRootFullName.Length).TrimStart("\", "/") -replace "\\", "/"
         if (
+            $relative -eq ".git" -or
             $relative.StartsWith(".git/", [System.StringComparison]::Ordinal) -or
             $relative.StartsWith("target/", [System.StringComparison]::Ordinal) -or
             $excludeSet.Contains($relative) -or
@@ -290,7 +291,9 @@ $privateTextLiteralFragments = @(
     ("GITHUB_" + "TOKEN")
 )
 $privateTextRegexFragments = @(
-    ("BEGIN " + ".*PRIVATE" + " KEY")
+    ("BEGIN " + ".*PRIVATE" + " KEY"),
+    ('(^|[^A-Za-z0-9_])' + '[A-Za-z]' + ':[\\/]' + '[^\s"''<>|]+'),
+    ('\\\\' + '[A-Za-z0-9_.-]+' + '\\' + '[A-Za-z0-9_.-]+')
 )
 $privateTextPatternParts = @()
 $privateTextPatternParts += $privateTextLiteralFragments | ForEach-Object {


### PR DESCRIPTION
## What changed

- Hardened public surface audits against generic absolute Windows drive paths and UNC local paths.
- Fixed the public export text scan so worktree `.git` pointer files are excluded consistently with the export allowlist.
- Updated PR, issue, support, README, and release checklist language to explicitly ban absolute local or UNC paths.

## Why

This tightens the public/private boundary before future release material lands, especially around accidental local path leakage from private workstations or worktrees.

## Validation

- `node scripts/audit_public_github_state.mjs`
- `node scripts/validate_public_release_manifests.mjs`
- `node scripts/validate_public_release_state.mjs`
- `node scripts/audit_public_secrets.mjs`
- `python scripts/audit_public_surface.py`
- `powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1`
- `git diff --check`