### PR TITLE
[codex] Harden public artifact manifest gates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,7 @@
 - [ ] `PUBLIC_RELEASE_CHECKLIST.md` was followed, or this PR does not change release status, artifacts, downloads, or public claims.
 - [ ] Any generated local config, including `workers/instnct-notify/wrangler.jsonc`, remains untracked.
 - [ ] Any new artifact has public-safe provenance, naming, and checksum or signature material where applicable.
+- [ ] Any `artifact_release` or `proof_pack` manifest includes the required published artifact, checksum, and signature fields.
 - [ ] Any artifact, checksum, signature, or release status claim change has a reviewed public manifest that follows `releases/public-release-manifest.schema.json`.
 - [ ] `PUBLIC_GITHUB_STATE.md` was checked for release, tag, asset, Pages, and branch-state changes, or this PR does not change public release state.
 

--- a/PUBLIC_RELEASE_CHECKLIST.md
+++ b/PUBLIC_RELEASE_CHECKLIST.md
@@ -66,6 +66,13 @@ If a public artifact is added:
 
 - name it with a stable release slug
 - include checksum or signature material when applicable
+- use `artifact_release` only when the manifest includes a published
+  non-documentation artifact
+- use `proof_pack` only when the manifest includes a published `proof_pack`
+  artifact
+- include SHA-256 for every published non-documentation artifact
+- include `signature_path_or_url` for every published `proof_pack` or `binary`
+  artifact
 - add a public release manifest that follows
   `releases/public-release-manifest.schema.json`
 - document how the artifact was produced at a public-safe level

--- a/releases/README.md
+++ b/releases/README.md
@@ -13,6 +13,17 @@ verification commands, and explicit exclusions.
 The manifest is intentionally public-safe. It should describe only reviewed
 public files, public URLs, public checks, and public artifact metadata.
 
+Artifact-bearing releases have stricter gates:
+
+- `artifact_release` manifests must include at least one published
+  non-documentation artifact.
+- `proof_pack` manifests must include at least one published `proof_pack`
+  artifact.
+- Every published non-documentation artifact must include a lowercase SHA-256
+  checksum.
+- Published `proof_pack` and `binary` artifacts must also include
+  `signature_path_or_url`.
+
 Validate manifests before review:
 
 ```powershell
@@ -31,7 +42,7 @@ Do not include:
 - private engine source
 - non-public training data
 - raw operator output
-- local machine paths
+- absolute local or UNC machine paths
 - secrets or filled production config
 - private dashboard links
 

--- a/releases/public-release-manifest.schema.json
+++ b/releases/public-release-manifest.schema.json
@@ -155,6 +155,83 @@
       }
     }
   },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "release_kind": {
+            "const": "artifact_release"
+          }
+        },
+        "required": [
+          "release_kind"
+        ]
+      },
+      "then": {
+        "properties": {
+          "artifacts": {
+            "minItems": 1,
+            "contains": {
+              "type": "object",
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "repository_zip",
+                    "proof_pack",
+                    "checksum",
+                    "signature",
+                    "binary",
+                    "other"
+                  ]
+                },
+                "status": {
+                  "const": "published"
+                }
+              },
+              "required": [
+                "kind",
+                "status"
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "release_kind": {
+            "const": "proof_pack"
+          }
+        },
+        "required": [
+          "release_kind"
+        ]
+      },
+      "then": {
+        "properties": {
+          "artifacts": {
+            "minItems": 1,
+            "contains": {
+              "type": "object",
+              "properties": {
+                "kind": {
+                  "const": "proof_pack"
+                },
+                "status": {
+                  "const": "published"
+                }
+              },
+              "required": [
+                "kind",
+                "status"
+              ]
+            }
+          }
+        }
+      }
+    }
+  ],
   "$defs": {
     "repo_relative_path": {
       "type": "string",
@@ -227,7 +304,67 @@
           "type": "string",
           "maxLength": 500
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "enum": [
+                  "repository_zip",
+                  "proof_pack",
+                  "checksum",
+                  "signature",
+                  "binary",
+                  "other"
+                ]
+              },
+              "status": {
+                "const": "published"
+              }
+            },
+            "required": [
+              "kind",
+              "status"
+            ]
+          },
+          "then": {
+            "properties": {
+              "sha256": {
+                "type": "string",
+                "pattern": "^[a-f0-9]{64}$"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "enum": [
+                  "proof_pack",
+                  "binary"
+                ]
+              },
+              "status": {
+                "const": "published"
+              }
+            },
+            "required": [
+              "kind",
+              "status"
+            ]
+          },
+          "then": {
+            "properties": {
+              "signature_path_or_url": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/scripts/audit_public_surface.py
+++ b/scripts/audit_public_surface.py
@@ -128,6 +128,8 @@ REQUIRED_PR_TEMPLATE_MARKERS = {
     "What stays private?",
     "PUBLIC_RELEASE_CHECKLIST.md",
     "absolute local or UNC paths",
+    "artifact_release",
+    "required published artifact",
     "Release manifest checked:",
     "releases/public-release-manifest.schema.json",
     "node scripts\\validate_public_release_manifests.mjs",
@@ -179,11 +181,15 @@ REQUIRED_GITHUB_STATE_MARKERS = {
 }
 
 REQUIRED_RELEASE_MANIFEST_README_MARKERS = {
+    "artifact_release",
     "public-sdk-p11-20260629.manifest.json",
     "public-release-manifest.example.json",
     "public-release-manifest.schema.json",
     "releases/<release-slug>.manifest.json",
     "node scripts\\validate_public_release_manifests.mjs",
+    "published `proof_pack`",
+    "published non-documentation artifact",
+    "signature_path_or_url",
     "private engine source",
     "non-public training data",
     "raw operator output",

--- a/scripts/validate_public_release_manifests.mjs
+++ b/scripts/validate_public_release_manifests.mjs
@@ -58,6 +58,18 @@ const REQUIRED_GITHUB_CHECKS = [
   "CodeQL",
   "Cloudflare Pages",
 ];
+const PUBLISHED_ARTIFACT_KINDS_REQUIRING_SHA256 = new Set([
+  "repository_zip",
+  "proof_pack",
+  "checksum",
+  "signature",
+  "binary",
+  "other",
+]);
+const PUBLISHED_ARTIFACT_KINDS_REQUIRING_SIGNATURE = new Set([
+  "proof_pack",
+  "binary",
+]);
 
 const failures = [];
 const trackedFiles = new Set(
@@ -240,11 +252,17 @@ function validateArtifact(file, artifact, index) {
   }
   if (
     artifact.status === "published" &&
-    artifact.kind !== "documentation" &&
-    artifact.kind !== "signature" &&
+    PUBLISHED_ARTIFACT_KINDS_REQUIRING_SHA256.has(artifact.kind) &&
     artifact.sha256 === null
   ) {
     fail(file, `artifacts[${index}] is published and must include sha256`);
+  }
+  if (
+    artifact.status === "published" &&
+    PUBLISHED_ARTIFACT_KINDS_REQUIRING_SIGNATURE.has(artifact.kind) &&
+    artifact.signature_path_or_url === null
+  ) {
+    fail(file, `artifacts[${index}] is published and must include signature_path_or_url`);
   }
 
   if (artifact.signature_path_or_url !== null) {
@@ -342,6 +360,19 @@ function validateManifest(file, manifest) {
     fail(file, "artifacts must be an array");
   } else {
     manifest.artifacts.forEach((artifact, index) => validateArtifact(file, artifact, index));
+    const publishedArtifacts = manifest.artifacts.filter((artifact) => artifact?.status === "published");
+    if (
+      manifest.release_kind === "artifact_release" &&
+      !publishedArtifacts.some((artifact) => artifact?.kind !== "documentation")
+    ) {
+      fail(file, "artifact_release manifests must include at least one published non-documentation artifact");
+    }
+    if (
+      manifest.release_kind === "proof_pack" &&
+      !publishedArtifacts.some((artifact) => artifact?.kind === "proof_pack")
+    ) {
+      fail(file, "proof_pack manifests must include at least one published proof_pack artifact");
+    }
   }
 
   if (assertExactKeys(file, "exclusions", manifest.exclusions, REQUIRED_EXCLUSIONS)) {


### PR DESCRIPTION
## What changed

- Tightened the public release manifest schema for artifact-bearing releases.
- `artifact_release` now requires a published non-documentation artifact.
- `proof_pack` now requires a published `proof_pack` artifact.
- Published non-documentation artifacts require SHA-256; published `proof_pack` and `binary` artifacts also require `signature_path_or_url`.
- Updated release checklist, release manifest README, PR template, and public surface audit markers to match the stricter gate.

## Why

This prepares the public repo to receive the future training/proof release without allowing an empty, pending-only, or under-specified artifact manifest to become the public source of truth.

## Validation

- `node --check scripts/validate_public_release_manifests.mjs`
- `node scripts/validate_public_release_manifests.mjs`
- `node scripts/validate_public_release_state.mjs`
- `node scripts/sync_public_release_links.mjs --check`
- `node scripts/audit_public_secrets.mjs`
- `python scripts/audit_public_surface.py`
- `node scripts/audit_public_github_state.mjs`
- `powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1`
- `git diff --check`