### PR TITLE
[codex] Verify public manifest schema contract

### DIFF
--- a/releases/README.md
+++ b/releases/README.md
@@ -24,6 +24,10 @@ Artifact-bearing releases have stricter gates:
 - Published `proof_pack` and `binary` artifacts must also include
   `signature_path_or_url`.
 
+`validate_public_release_manifests.mjs` checks both manifest content and the
+schema contract, so these artifact gates must stay encoded in
+`public-release-manifest.schema.json`.
+
 Validate manifests before review:
 
 ```powershell

--- a/scripts/audit_public_surface.py
+++ b/scripts/audit_public_surface.py
@@ -190,6 +190,7 @@ REQUIRED_RELEASE_MANIFEST_README_MARKERS = {
     "published `proof_pack`",
     "published non-documentation artifact",
     "signature_path_or_url",
+    "schema contract",
     "private engine source",
     "non-public training data",
     "raw operator output",

--- a/scripts/validate_public_release_manifests.mjs
+++ b/scripts/validate_public_release_manifests.mjs
@@ -193,6 +193,27 @@ function assertDate(file, releaseDate, releaseSlug) {
   }
 }
 
+function includesEvery(actual, expected) {
+  return expected.every((item) => Array.isArray(actual) && actual.includes(item));
+}
+
+function findReleaseKindRule(schema, releaseKind) {
+  const rules = Array.isArray(schema?.allOf) ? schema.allOf : [];
+  return rules.find((rule) => rule?.if?.properties?.release_kind?.const === releaseKind);
+}
+
+function findPublishedArtifactRule(schema, requiredKinds, thenProperty) {
+  const rules = Array.isArray(schema?.$defs?.artifact?.allOf) ? schema.$defs.artifact.allOf : [];
+  return rules.find((rule) => {
+    const kindEnum = rule?.if?.properties?.kind?.enum;
+    return (
+      rule?.if?.properties?.status?.const === "published" &&
+      includesEvery(kindEnum, requiredKinds) &&
+      isPlainObject(rule?.then?.properties?.[thenProperty])
+    );
+  });
+}
+
 function validateSchemaContract(schema) {
   const file = "releases/public-release-manifest.schema.json";
   if (!schema) {
@@ -211,6 +232,59 @@ function validateSchemaContract(schema) {
     if (exclusions?.[exclusion]?.const !== false) {
       fail(file, `exclusion must be const false: ${exclusion}`);
     }
+  }
+
+  const artifactReleaseRule = findReleaseKindRule(schema, "artifact_release");
+  const artifactReleaseContains = artifactReleaseRule?.then?.properties?.artifacts?.contains;
+  if (artifactReleaseRule?.then?.properties?.artifacts?.minItems !== 1) {
+    fail(file, "artifact_release schema rule must require at least one artifact");
+  }
+  if (artifactReleaseContains?.properties?.status?.const !== "published") {
+    fail(file, "artifact_release schema rule must require a published artifact");
+  }
+  if (
+    !includesEvery(
+      artifactReleaseContains?.properties?.kind?.enum,
+      [...PUBLISHED_ARTIFACT_KINDS_REQUIRING_SHA256],
+    )
+  ) {
+    fail(file, "artifact_release schema rule must require a published non-documentation artifact kind");
+  }
+
+  const proofPackRule = findReleaseKindRule(schema, "proof_pack");
+  const proofPackContains = proofPackRule?.then?.properties?.artifacts?.contains;
+  if (proofPackRule?.then?.properties?.artifacts?.minItems !== 1) {
+    fail(file, "proof_pack schema rule must require at least one artifact");
+  }
+  if (
+    proofPackContains?.properties?.kind?.const !== "proof_pack" ||
+    proofPackContains?.properties?.status?.const !== "published"
+  ) {
+    fail(file, "proof_pack schema rule must require a published proof_pack artifact");
+  }
+
+  const sha256Rule = findPublishedArtifactRule(
+    schema,
+    [...PUBLISHED_ARTIFACT_KINDS_REQUIRING_SHA256],
+    "sha256",
+  );
+  if (
+    sha256Rule?.then?.properties?.sha256?.type !== "string" ||
+    sha256Rule?.then?.properties?.sha256?.pattern !== "^[a-f0-9]{64}$"
+  ) {
+    fail(file, "published non-documentation artifact schema rule must require lowercase SHA-256");
+  }
+
+  const signatureRule = findPublishedArtifactRule(
+    schema,
+    [...PUBLISHED_ARTIFACT_KINDS_REQUIRING_SIGNATURE],
+    "signature_path_or_url",
+  );
+  if (
+    signatureRule?.then?.properties?.signature_path_or_url?.type !== "string" ||
+    signatureRule?.then?.properties?.signature_path_or_url?.minLength !== 1
+  ) {
+    fail(file, "published proof_pack/binary artifact schema rule must require signature_path_or_url");
   }
 }
 


### PR DESCRIPTION
## What changed

- Added structured schema-contract assertions to `validate_public_release_manifests.mjs`.
- The validator now verifies that `public-release-manifest.schema.json` itself encodes the artifact-bearing release gates for `artifact_release`, `proof_pack`, SHA-256, and `signature_path_or_url`.
- Documented that the manifest validator checks both manifest content and schema contract.
- Added a public surface audit marker for the schema-contract documentation.

## Why

The previous hardening made the validator enforce artifact release policy, but the schema contract could drift separately. This keeps the public schema aligned with the validator before future training/proof release artifacts are accepted.

## Validation

- `node --check scripts/validate_public_release_manifests.mjs`
- `node scripts/validate_public_release_manifests.mjs`
- `python scripts/audit_public_surface.py`
- `node scripts/audit_public_secrets.mjs`
- `node scripts/validate_public_release_state.mjs`
- `node scripts/sync_public_release_links.mjs --check`
- `node scripts/audit_public_github_state.mjs`
- `powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1`
- `git diff --check`