### PR TITLE
[codex] Self-test public manifest policy gates

### DIFF
--- a/releases/README.md
+++ b/releases/README.md
@@ -26,7 +26,9 @@ Artifact-bearing releases have stricter gates:
 
 `validate_public_release_manifests.mjs` checks both manifest content and the
 schema contract, so these artifact gates must stay encoded in
-`public-release-manifest.schema.json`.
+`public-release-manifest.schema.json`. It also runs in-memory policy self-tests
+that must reject representative bad `artifact_release`, `proof_pack`, checksum,
+signature, and schema-drift cases before reporting `policy_self_tests`.
 
 Validate manifests before review:
 

--- a/scripts/audit_public_surface.py
+++ b/scripts/audit_public_surface.py
@@ -189,6 +189,8 @@ REQUIRED_RELEASE_MANIFEST_README_MARKERS = {
     "node scripts\\validate_public_release_manifests.mjs",
     "published `proof_pack`",
     "published non-documentation artifact",
+    "policy_self_tests",
+    "policy self-tests",
     "signature_path_or_url",
     "schema contract",
     "private engine source",

--- a/scripts/validate_public_release_manifests.mjs
+++ b/scripts/validate_public_release_manifests.mjs
@@ -491,6 +491,144 @@ function validateManifest(file, manifest) {
   }
 }
 
+function cloneJson(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function captureValidationFailures(callback) {
+  const start = failures.length;
+  callback();
+  return failures.splice(start);
+}
+
+function selfTestReleaseManifest(baseManifest, slug, releaseKind) {
+  const releaseDate = slug.slice(-8).replace(/^([0-9]{4})([0-9]{2})([0-9]{2})$/, "$1-$2-$3");
+  const manifest = cloneJson(baseManifest);
+  manifest.release_slug = slug;
+  manifest.release_date = releaseDate;
+  manifest.release_kind = releaseKind;
+  manifest.public_claim = "In-memory validator self-test only; never a public release.";
+  manifest.source_of_truth.github_release = `https://github.com/VRAXION/VRAXION/releases/tag/${slug}`;
+  manifest.artifacts = [];
+  return manifest;
+}
+
+function selfTestArtifact(slug, kind, overrides = {}) {
+  return {
+    name: `${kind}-self-test.zip`,
+    kind,
+    status: "published",
+    path_or_url: `https://github.com/VRAXION/VRAXION/releases/download/${slug}/${kind}-self-test.zip`,
+    sha256: "a".repeat(64),
+    signature_path_or_url: `https://github.com/VRAXION/VRAXION/releases/download/${slug}/${kind}-self-test.zip.sig`,
+    notes: "In-memory validator self-test artifact metadata.",
+    ...overrides,
+  };
+}
+
+function runManifestNegativeSelfTest(name, expectedText, callback) {
+  const captured = captureValidationFailures(callback);
+  if (!captured.some((failure) => failure.includes(expectedText))) {
+    fail(
+      "scripts/validate_public_release_manifests.mjs",
+      `policy self-test ${name} did not fail with ${JSON.stringify(expectedText)}; got ${captured.length ? captured.join(" | ") : "no failures"}`,
+    );
+  }
+}
+
+function runManifestPositiveSelfTest(name, callback) {
+  const captured = captureValidationFailures(callback);
+  if (captured.length > 0) {
+    fail(
+      "scripts/validate_public_release_manifests.mjs",
+      `policy self-test ${name} should pass; got ${captured.join(" | ")}`,
+    );
+  }
+}
+
+function runPolicySelfTests(schema, baseManifest) {
+  if (!schema || !baseManifest) {
+    return 0;
+  }
+
+  const tests = [
+    () => {
+      const slug = "public-selftest-proof-20990101";
+      const manifest = selfTestReleaseManifest(baseManifest, slug, "proof_pack");
+      manifest.artifacts = [selfTestArtifact(slug, "proof_pack")];
+      runManifestPositiveSelfTest("valid_proof_pack_manifest", () => {
+        validateManifest(`releases/${slug}.manifest.json`, manifest);
+      });
+    },
+    () => {
+      const slug = "public-selftest-empty-artifact-20990101";
+      const manifest = selfTestReleaseManifest(baseManifest, slug, "artifact_release");
+      runManifestNegativeSelfTest(
+        "artifact_release_without_published_artifact",
+        "artifact_release manifests must include at least one published non-documentation artifact",
+        () => validateManifest(`releases/${slug}.manifest.json`, manifest),
+      );
+    },
+    () => {
+      const slug = "public-selftest-proof-missing-20990101";
+      const manifest = selfTestReleaseManifest(baseManifest, slug, "proof_pack");
+      manifest.artifacts = [selfTestArtifact(slug, "binary")];
+      runManifestNegativeSelfTest(
+        "proof_pack_without_published_proof_pack_artifact",
+        "proof_pack manifests must include at least one published proof_pack artifact",
+        () => validateManifest(`releases/${slug}.manifest.json`, manifest),
+      );
+    },
+    () => {
+      const slug = "public-selftest-binary-sha-20990101";
+      const manifest = selfTestReleaseManifest(baseManifest, slug, "artifact_release");
+      manifest.artifacts = [selfTestArtifact(slug, "binary", { sha256: null })];
+      runManifestNegativeSelfTest(
+        "published_binary_without_sha256",
+        "is published and must include sha256",
+        () => validateManifest(`releases/${slug}.manifest.json`, manifest),
+      );
+    },
+    () => {
+      const slug = "public-selftest-proof-sig-20990101";
+      const manifest = selfTestReleaseManifest(baseManifest, slug, "proof_pack");
+      manifest.artifacts = [selfTestArtifact(slug, "proof_pack", { signature_path_or_url: null })];
+      runManifestNegativeSelfTest(
+        "published_proof_pack_without_signature",
+        "is published and must include signature_path_or_url",
+        () => validateManifest(`releases/${slug}.manifest.json`, manifest),
+      );
+    },
+    () => {
+      const driftedSchema = cloneJson(schema);
+      driftedSchema.allOf = (driftedSchema.allOf || []).filter(
+        (rule) => rule?.if?.properties?.release_kind?.const !== "artifact_release",
+      );
+      runManifestNegativeSelfTest(
+        "schema_without_artifact_release_rule",
+        "artifact_release schema rule must require at least one artifact",
+        () => validateSchemaContract(driftedSchema),
+      );
+    },
+    () => {
+      const driftedSchema = cloneJson(schema);
+      driftedSchema.$defs.artifact.allOf = (driftedSchema.$defs.artifact.allOf || []).filter(
+        (rule) => !isPlainObject(rule?.then?.properties?.signature_path_or_url),
+      );
+      runManifestNegativeSelfTest(
+        "schema_without_signature_rule",
+        "published proof_pack/binary artifact schema rule must require signature_path_or_url",
+        () => validateSchemaContract(driftedSchema),
+      );
+    },
+  ];
+
+  for (const run of tests) {
+    run();
+  }
+  return tests.length;
+}
+
 const schema = readJson("releases/public-release-manifest.schema.json");
 validateSchemaContract(schema);
 
@@ -515,8 +653,14 @@ for (const manifestFile of manifestFiles) {
   validateManifest(manifestFile, readJson(manifestFile));
 }
 
+const policySelfTests = runPolicySelfTests(
+  schema,
+  readJson("releases/public-release-manifest.example.json"),
+);
+
 console.log("PUBLIC_RELEASE_MANIFEST_VALIDATION");
 console.log(`manifest_files=${manifestFiles.length}`);
+console.log(`policy_self_tests=${policySelfTests}`);
 console.log(`failure_count=${failures.length}`);
 for (const failure of failures) {
   console.log(`failure: ${failure}`);


### PR DESCRIPTION
## Summary
- add in-memory negative policy self-tests to the public release manifest validator
- require representative bad artifact_release, proof_pack, checksum, signature, and schema-drift cases to be rejected before success output
- document the policy_self_tests guard and keep the public surface audit requiring that documentation

## Safety
- no new public artifact or release claim
- no private source or private training material added

## Validation
- node --check scripts/validate_public_release_manifests.mjs
- node scripts/validate_public_release_manifests.mjs
- python scripts/audit_public_surface.py
- node scripts/audit_public_secrets.mjs
- node scripts/validate_public_release_state.mjs
- node scripts/sync_public_release_links.mjs --check
- git diff --check
- powershell -ExecutionPolicy Bypass -File scripts\\check_public_export.ps1
- node scripts/audit_public_github_state.mjs