### PR TITLE
[codex] Harden public copy regression audit

### DIFF
--- a/docs/PUBLIC_SURFACE_POLICY.md
+++ b/docs/PUBLIC_SURFACE_POLICY.md
@@ -20,3 +20,6 @@ Not allowed:
 - private engine binary internals
 
 The audit script is a hard gate for this public surface.
+It also guards against stale public-copy terms that would imply a released
+archive, live availability, hosted service, or public runtime beyond the
+reviewed SDK/docs state.

--- a/scripts/audit_public_surface.py
+++ b/scripts/audit_public_surface.py
@@ -27,9 +27,15 @@ FORBIDDEN_PATH_PARTS = [
     marker("vraxion-", "runtime"),
     marker("docs/", "research"),
     marker("tools/", "private_data_adapters"),
+    marker("docs/", "van", "guard"),
     marker("docs/", "vn", "gard"),
     marker("red", "b"),
 ]
+
+REQUIRED_FORBIDDEN_PATH_PARTS = {
+    marker("docs/", "van", "guard"),
+    marker("tools/", "private_data_adapters"),
+}
 
 FORBIDDEN_TEXT = [
     marker("Fine", "Web"),
@@ -75,11 +81,13 @@ FORBIDDEN_PUBLIC_COPY = [
     marker("public source ", "archive"),
     marker("boundary ", "snapshot"),
     marker("boundary ", "archive"),
+    marker("SDK ", "bound", "ary"),
     marker("P11 ", "SDK ", "bound", "ary"),
     marker("P11 ", "delivery decision"),
     marker("zero-state ", "SDK"),
     marker("docs/", "vn", "gard"),
     marker("docs\\", "vn", "gard"),
+    marker("van", "guard"),
     "local reasoning runtime",
     "runtime project",
     "governed runtime frame",
@@ -93,6 +101,21 @@ FORBIDDEN_PUBLIC_COPY = [
     "make local intelligence",
     "production backend target",
 ]
+
+REQUIRED_FORBIDDEN_PUBLIC_COPY_MARKERS = {
+    marker("source", "-available"),
+    marker("source ", "available"),
+    marker("source ", "archive"),
+    marker("public source ", "archive"),
+    marker("boundary ", "archive"),
+    marker("boundary ", "snapshot"),
+    marker("SDK ", "bound", "ary"),
+    marker("van", "guard"),
+    "hosted api / saas later",
+    "hosted api/saas later",
+    "preview live",
+    "signed offline verification",
+}
 
 EXPECTED_CRATES = {"alphasync-core", "alphasync-runtime"}
 
@@ -346,6 +369,17 @@ def main() -> int:
     warnings: list[str] = []
     files = tracked_files()
     file_set = {relative.replace("\\", "/") for relative in files}
+    forbidden_public_copy_markers = {
+        marker_text.lower() for marker_text in FORBIDDEN_PUBLIC_COPY
+    }
+    forbidden_path_parts = {path_part.lower() for path_part in FORBIDDEN_PATH_PARTS}
+
+    for required in sorted(REQUIRED_FORBIDDEN_PATH_PARTS):
+        if required.lower() not in forbidden_path_parts:
+            failures.append(f"forbidden path marker is not guarded: {required}")
+    for required in sorted(REQUIRED_FORBIDDEN_PUBLIC_COPY_MARKERS):
+        if required.lower() not in forbidden_public_copy_markers:
+            failures.append(f"forbidden public copy marker is not guarded: {required}")
 
     for required in sorted(REQUIRED_TRACKED_FILES):
         if required not in file_set:
@@ -575,6 +609,8 @@ def main() -> int:
 
     print("PUBLIC_SURFACE_AUDIT")
     print(f"tracked_files={len(files)}")
+    print(f"forbidden_path_markers={len(FORBIDDEN_PATH_PARTS)}")
+    print(f"forbidden_public_copy_markers={len(FORBIDDEN_PUBLIC_COPY)}")
     print(f"failure_count={len(failures)}")
     print(f"warning_count={len(warnings)}")
     for failure in failures:


### PR DESCRIPTION
## Summary
- require the public surface audit to keep critical forbidden path and public-copy markers guarded
- add explicit path/copy blocks for stale Vanguard and SDK-boundary public exposure regressions
- document that stale public-copy promises are part of the public surface hard gate

## Safety
- no new public release claim
- no private source, private training data, or public artifact added
- prevents previously removed wording/classes from reappearing in public docs/pages

## Validation
- python scripts/audit_public_surface.py
- node scripts/audit_public_secrets.mjs
- rg -n -i "source available|source-available|source archive|boundary archive|sdk boundary|vanguard|preview live|signed offline verification|hosted api / saas later|hosted api/saas later" --glob "*.md" --glob "*.html" --glob "*.cff"
- git diff --check
- node scripts/validate_public_release_manifests.mjs
- node scripts/validate_public_release_state.mjs
- node scripts/sync_public_release_links.mjs --check
- powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1
- node scripts/audit_public_github_state.mjs