### PR TITLE
[codex] Align public export path guards

### DIFF
--- a/docs/PUBLIC_SURFACE_POLICY.md
+++ b/docs/PUBLIC_SURFACE_POLICY.md
@@ -13,6 +13,7 @@ Not allowed:
 
 - internal engine source
 - private data adapters
+- private workspace path families
 - operational run outputs
 - skill persistence
 - diagnostic tools

--- a/scripts/check_public_export.ps1
+++ b/scripts/check_public_export.ps1
@@ -218,8 +218,25 @@ $forbiddenPublicPathFragments = @(
     ("golden_" + "legacy_parity"),
     ("alphasync-" + "selftrain"),
     ("alphasync-" + "skillstore"),
-    ("docs/" + "vn" + "gard")
+    ("vraxion-" + "runtime"),
+    ("docs/" + "research"),
+    ("tools/" + "private_data_adapters"),
+    ("docs/" + "van" + "guard"),
+    ("docs/" + "vn" + "gard"),
+    ("red" + "b")
 )
+$requiredForbiddenPublicPathFragments = @(
+    ("docs/" + "research"),
+    ("docs/" + "van" + "guard"),
+    ("tools/" + "private_data_adapters"),
+    ("vraxion-" + "runtime")
+)
+$forbiddenPublicPathFragmentSet = New-OrdinalSet -Items $forbiddenPublicPathFragments
+foreach ($fragment in $requiredForbiddenPublicPathFragments) {
+    if (-not $forbiddenPublicPathFragmentSet.Contains($fragment)) {
+        throw "forbidden public path fragment is not guarded: $fragment"
+    }
+}
 $maxPublicBinaryAssetBytes = 4MB
 $publicBinaryAssets = @(
     "docs/assets/vraxion-home-hero.jpg",


### PR DESCRIPTION
## Summary
- align the PowerShell public export path guard with the Python public surface path guard
- add explicit forbidden fragments for private workspace path families such as docs/research, docs/vanguard, tools/private_data_adapters, and vraxion-runtime
- make the export guard self-check that the critical forbidden path fragments remain present
- document private workspace path families as outside the public surface

## Safety
- no new public release claim or artifact
- no private source, private training data, or local path added
- makes accidental private workspace paths fail before they can be allowlisted into the public export

## Validation
- negative check: temporary docs/vanguard/guard_regression_test.txt fails as `forbidden private path fragment 'docs/vanguard' in public export path: docs/vanguard/guard_regression_test.txt`
- python scripts/audit_public_surface.py
- node scripts/audit_public_secrets.mjs
- git diff --check
- node scripts/validate_public_release_manifests.mjs
- node scripts/validate_public_release_state.mjs
- node scripts/sync_public_release_links.mjs --check
- powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1
- node scripts/audit_public_github_state.mjs