### PR TITLE
[codex] Harden release link sync coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo doc --workspace --no-deps
 node scripts/validate_public_release_manifests.mjs
 node scripts/validate_public_release_state.mjs
+node scripts/sync_public_release_links.mjs --check
 node scripts/audit_public_secrets.mjs
 python scripts/audit_public_surface.py
 powershell -ExecutionPolicy Bypass -File scripts/check_public_export.ps1

--- a/scripts/audit_public_surface.py
+++ b/scripts/audit_public_surface.py
@@ -221,6 +221,16 @@ REQUIRED_RELEASE_MANIFEST_README_MARKERS = {
     "raw operator output",
 }
 
+REQUIRED_RELEASE_LINK_SYNC_MARKERS = {
+    "requiredCurrentStateFiles",
+    "README.md",
+    "PUBLIC_GITHUB_STATE.md",
+    "docs/CURRENT_STATUS.md",
+    "docs/CURRENT_CAPABILITIES.md",
+    "current-state release link file is not scanned",
+    "public_release_link_files",
+}
+
 REQUIRED_RELEASE_MANIFEST_EXCLUSIONS = {
     "private_engine_source",
     "non_public_training_data",
@@ -445,6 +455,11 @@ def main() -> int:
     for required in sorted(REQUIRED_RELEASE_MANIFEST_README_MARKERS):
         if required not in release_manifest_readme:
             failures.append(f"release manifest readme missing marker: {required}")
+
+    release_link_sync = read_text(ROOT / "scripts" / "sync_public_release_links.mjs")
+    for required in sorted(REQUIRED_RELEASE_LINK_SYNC_MARKERS):
+        if required not in release_link_sync:
+            failures.append(f"release link sync missing coverage marker: {required}")
 
     gitattributes_path = ROOT / ".gitattributes"
     gitattributes_entries = {

--- a/scripts/sync_public_release_links.mjs
+++ b/scripts/sync_public_release_links.mjs
@@ -7,6 +7,15 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const versionPath = path.join(root, "docs", "VERSION.json");
 const releaseSlugPattern = /public-sdk-p\d+-\d{8}/g;
 const publicTextExtensions = new Set([".html", ".md", ".json", ".txt", ".xml"]);
+const requiredCurrentStateFiles = new Set([
+  "README.md",
+  "PUBLIC_GITHUB_STATE.md",
+  "docs/CURRENT_STATUS.md",
+  "docs/CURRENT_CAPABILITIES.md",
+  "docs/index.html",
+  "docs/instnct/index.html",
+]);
+const extraCurrentStateFiles = new Set(["LICENSE_BOUNDARY.md", "PUBLIC_DELIVERY_MODEL.md"]);
 const args = new Set(process.argv.slice(2));
 const write = args.has("--write");
 
@@ -25,7 +34,7 @@ function trackedFiles() {
 }
 
 function isPublicTextFile(relative) {
-  if (!relative.startsWith("docs/") && !["LICENSE_BOUNDARY.md", "PUBLIC_DELIVERY_MODEL.md"].includes(relative)) {
+  if (!relative.startsWith("docs/") && !extraCurrentStateFiles.has(relative) && !requiredCurrentStateFiles.has(relative)) {
     return false;
   }
   return publicTextExtensions.has(path.extname(relative).toLowerCase());
@@ -46,6 +55,11 @@ const files = trackedFiles();
 const fileSet = new Set(files);
 const releaseFiles = files.filter(isPublicTextFile);
 const changed = [];
+
+for (const required of requiredCurrentStateFiles) {
+  if (!fileSet.has(required)) fail(`required current-state release link file is missing: ${required}`);
+  if (!releaseFiles.includes(required)) fail(`current-state release link file is not scanned: ${required}`);
+}
 
 for (const relative of releaseFiles) {
   const absolute = path.join(root, relative);
@@ -82,5 +96,6 @@ if (write) {
 } else if (process.exitCode) {
   process.exit(process.exitCode);
 } else {
+  console.log(`public_release_link_files=${releaseFiles.length}`);
   console.log("public_release_links=pass");
 }


### PR DESCRIPTION
## Summary
- Include current root public-state docs in the public release link sync scan.
- Require README.md, PUBLIC_GITHUB_STATE.md, CURRENT_STATUS, CURRENT_CAPABILITIES, home, and INSTNCT pages to stay scanned.
- Surface the scanned release-link file count as `public_release_link_files`.
- Make the public surface audit guard the sync coverage markers.
- Document the sync check in the README build/check list.

## Safety
- No new public artifact or release claim.
- No private source, training data, or local path added.
- Reduces stale release slug risk when the training release updates `docs/VERSION.json`.

## Validation
- `node --check scripts/sync_public_release_links.mjs`
- `node scripts/sync_public_release_links.mjs --check`
- `python scripts/audit_public_surface.py`
- `node scripts/audit_public_secrets.mjs`
- `node scripts/validate_public_release_state.mjs`
- `node scripts/validate_public_release_manifests.mjs`
- `git diff --check`
- `powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1`