### PR TITLE
[codex] Align contributor public gates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,13 +7,17 @@ Before opening a pull request, run:
 
 ```powershell
 node scripts\sync_public_release_links.mjs --check
+node scripts\validate_public_release_manifests.mjs
+node scripts\validate_public_release_state.mjs
+node scripts\audit_public_secrets.mjs
 node scripts\audit_instnct_static_site.mjs
 node scripts\audit_instnct_notify_worker.mjs
+python scripts\audit_public_surface.py
+node scripts\smoke_public_pages_links.mjs
 cargo fmt --all -- --check
 cargo test --workspace --all-features
 cargo test --doc --workspace --all-features
 cargo clippy --workspace --all-targets --all-features -- -D warnings
-python scripts/audit_public_surface.py
 powershell -ExecutionPolicy Bypass -File scripts/check_public_export.ps1
 ```
 
@@ -23,13 +27,15 @@ tools to this repository.
 Release PRs must also follow `PUBLIC_RELEASE_CHECKLIST.md`. If a release
 changes public status, artifacts, downloads, or claims, state exactly what
 became public and what stayed private in the PR body.
+For release-state PRs, also run `node scripts\audit_public_github_state.mjs`
+before opening the final PR and again after merge.
 
 Use the GitHub pull request template. Do not delete the public scope,
 release-intake, or required-gates sections from release or public-surface PRs.
 
 Use the GitHub issue form for public reports. Do not put secrets, private code,
-non-public training data, local machine paths, raw operator output, production
-config, or private dashboards in public issues. Use `SECURITY.md` for
+non-public training data, absolute local or UNC paths, raw operator output,
+production config, or private dashboards in public issues. Use `SECURITY.md` for
 vulnerabilities or reports with security impact. Support routing is summarized
 in `SUPPORT.md`.
 

--- a/scripts/audit_public_surface.py
+++ b/scripts/audit_public_surface.py
@@ -129,6 +129,7 @@ REQUIRED_TRACKED_FILES = {
     ".github/workflows/deploy-instnct-notify.yml",
     ".github/workflows/public-pages-smoke.yml",
     ".github/workflows/public-surface-audit.yml",
+    "CONTRIBUTING.md",
     ".gitattributes",
     ".gitignore",
     "README.md",
@@ -165,6 +166,28 @@ REQUIRED_PR_TEMPLATE_MARKERS = {
     "node scripts\\audit_public_secrets.mjs",
     "workers/instnct-notify/wrangler.jsonc",
     "powershell -ExecutionPolicy Bypass -File scripts\\check_public_export.ps1",
+}
+
+REQUIRED_CONTRIBUTING_MARKERS = {
+    "PUBLIC_RELEASE_CHECKLIST.md",
+    "SECURITY.md",
+    "SUPPORT.md",
+    "node scripts\\sync_public_release_links.mjs --check",
+    "node scripts\\validate_public_release_manifests.mjs",
+    "node scripts\\validate_public_release_state.mjs",
+    "node scripts\\audit_public_secrets.mjs",
+    "node scripts\\audit_instnct_static_site.mjs",
+    "node scripts\\audit_instnct_notify_worker.mjs",
+    "python scripts\\audit_public_surface.py",
+    "node scripts\\smoke_public_pages_links.mjs",
+    "node scripts\\audit_public_github_state.mjs",
+    "cargo fmt --all -- --check",
+    "cargo test --workspace --all-features",
+    "cargo test --doc --workspace --all-features",
+    "cargo clippy --workspace --all-targets --all-features -- -D warnings",
+    "powershell -ExecutionPolicy Bypass -File scripts/check_public_export.ps1",
+    "non-public training data",
+    "absolute local or UNC paths",
 }
 
 REQUIRED_DEPENDABOT_MARKERS = {
@@ -421,6 +444,11 @@ def main() -> int:
     for required in sorted(REQUIRED_PR_TEMPLATE_MARKERS):
         if required not in pr_template:
             failures.append(f"pull request template missing release guard marker: {required}")
+
+    contributing_doc = read_text(ROOT / "CONTRIBUTING.md")
+    for required in sorted(REQUIRED_CONTRIBUTING_MARKERS):
+        if required not in contributing_doc:
+            failures.append(f"contributing doc missing public-gate marker: {required}")
 
     dependabot_config = read_text(ROOT / ".github" / "dependabot.yml")
     for required in sorted(REQUIRED_DEPENDABOT_MARKERS):


### PR DESCRIPTION
## Summary
- Align `CONTRIBUTING.md` with the public release/readiness gate list used by the PR template and checklist.
- Add release manifest/state, secret scan, public surface audit, and public Pages smoke commands to the contributor pre-PR flow.
- Add release-state guidance for `audit_public_github_state` before final release PRs and after merge.
- Make `scripts/audit_public_surface.py` guard the contributor gate list and public-safety wording.

## Safety
- No website, artifact, release claim, crate code, or Worker behavior changed.
- Reinforces the public/private boundary wording for public issue reports.
- Reduces drift between contributor docs and required public gates before the training release lands.

## Validation
- `python scripts/audit_public_surface.py`
- `node scripts/audit_public_secrets.mjs`
- `node scripts/sync_public_release_links.mjs --check`
- `node scripts/validate_public_release_manifests.mjs`
- `node scripts/validate_public_release_state.mjs`
- `git diff --check`
- `powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1`