### PR TITLE
[codex] Guard public security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,9 @@
 # Security Policy
 
 Report security issues privately by opening a GitHub security advisory or by
-contacting the project maintainers through the repository owner profile.
+contacting the project maintainers through the repository owner profile. Do not
+open a public issue for vulnerabilities, suspected secret exposure, or reports
+that require private material to explain the impact.
 
 Please do not publish exploit details before maintainers have had time to
 investigate and respond.
@@ -17,6 +19,12 @@ This public repository currently includes:
 
 The private engine implementation, non-public training data, private run
 infrastructure, and operator-only workspace are outside this repository.
+
+Security reports should use only public reproduction material unless a private
+review path has been opened. Do not paste secrets, tokens, private code,
+non-public training data, raw operator output, absolute local or UNC machine
+paths, production config, private dashboards, or credential values into public
+issues, pull requests, comments, or discussions.
 
 ## Reporting Checklist
 
@@ -40,3 +48,6 @@ increase risk before users can update.
 
 Run `node scripts\audit_public_secrets.mjs` before release PRs that touch
 configuration, Worker code, release artifacts, or generated files.
+For release-state or GitHub release changes, also run
+`node scripts\audit_public_github_state.mjs` before opening the final PR and
+again after merge.

--- a/scripts/audit_public_surface.py
+++ b/scripts/audit_public_surface.py
@@ -148,6 +148,7 @@ REQUIRED_TRACKED_FILES = {
     "scripts/validate_public_release_state.mjs",
     "scripts/sync_public_release_links.mjs",
     "LICENSE_BOUNDARY.md",
+    "SECURITY.md",
     "SUPPORT.md",
 }
 
@@ -188,6 +189,24 @@ REQUIRED_CONTRIBUTING_MARKERS = {
     "powershell -ExecutionPolicy Bypass -File scripts/check_public_export.ps1",
     "non-public training data",
     "absolute local or UNC paths",
+}
+
+REQUIRED_SECURITY_MARKERS = {
+    "GitHub security advisory",
+    "open a public issue",
+    "vulnerabilities, suspected secret exposure",
+    "private material to explain the impact",
+    "Public Scope",
+    "non-public training data",
+    "raw operator output",
+    "absolute local or UNC machine",
+    "production config",
+    "private dashboards",
+    "PUBLIC_RELEASE_CHECKLIST.md",
+    "node scripts\\audit_public_secrets.mjs",
+    "node scripts\\audit_public_github_state.mjs",
+    "before opening the final PR and",
+    "again after merge",
 }
 
 REQUIRED_DEPENDABOT_MARKERS = {
@@ -449,6 +468,11 @@ def main() -> int:
     for required in sorted(REQUIRED_CONTRIBUTING_MARKERS):
         if required not in contributing_doc:
             failures.append(f"contributing doc missing public-gate marker: {required}")
+
+    security_doc = read_text(ROOT / "SECURITY.md")
+    for required in sorted(REQUIRED_SECURITY_MARKERS):
+        if required not in security_doc:
+            failures.append(f"security doc missing public-security marker: {required}")
 
     dependabot_config = read_text(ROOT / ".github" / "dependabot.yml")
     for required in sorted(REQUIRED_DEPENDABOT_MARKERS):


### PR DESCRIPTION
## Summary
- Strengthen `SECURITY.md` to route security-impact reports away from public issues.
- Add the same private-material exclusions used elsewhere: secrets, private code, non-public training data, raw operator output, absolute local or UNC machine paths, production config, private dashboards, and credential values.
- Add release-state guidance for `audit_public_github_state` around final PRs and post-merge checks.
- Make `scripts/audit_public_surface.py` guard the security policy markers and require `SECURITY.md` in the tracked public contract.

## Safety
- No website, artifact, release claim, crate code, or Worker behavior changed.
- Reduces public issue leakage risk and keeps security reporting aligned with support and issue templates.

## Validation
- `python scripts/audit_public_surface.py`
- `node scripts/audit_public_secrets.mjs`
- `node scripts/validate_public_release_state.mjs`
- `node scripts/validate_public_release_manifests.mjs`
- `node scripts/sync_public_release_links.mjs --check`
- `git diff --check`
- `powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1`