### PR TITLE
[codex] Guard public deployment runbook

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -23,10 +23,13 @@ Required local gates before pushing public site changes:
 
 ```powershell
 node scripts\sync_public_release_links.mjs --check
+node scripts\validate_public_release_manifests.mjs
+node scripts\validate_public_release_state.mjs
+node scripts\audit_public_secrets.mjs
 node scripts\audit_instnct_static_site.mjs
 python scripts\audit_public_surface.py
 node scripts\smoke_instnct_browser.mjs
-.\scripts\check_public_export.ps1
+powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1
 ```
 
 Required live gate after Pages deploy:
@@ -56,6 +59,9 @@ Required GitHub secrets:
 - `INSTNCT_NOTIFY_ADMIN_TOKEN`
 - `INSTNCT_NOTIFY_API_BASE`
 
+Do not commit `workers/instnct-notify/wrangler.jsonc`, `.dev.vars`, real D1
+database ids, Worker secret values, API tokens, or operator export data.
+
 Manual Cloudflare setup:
 
 ```powershell
@@ -82,6 +88,8 @@ Automated deploy:
 1. Open the `Deploy INSTNCT Notify Worker` workflow.
 2. Run it manually from `main`.
 3. Confirm the workflow ran migrations, deployed the Worker with the scheduled rate-limit cleanup trigger, and passed live smoke.
+4. Confirm no generated `wrangler.jsonc`, `.wrangler/`, `.dev.vars`, or Worker
+   secret material was committed.
 
 Post-deploy live smoke:
 
@@ -121,5 +129,7 @@ Do not add an active email form to `docs/instnct/index.html` until all of these 
 - Write-mode smoke has been run once intentionally.
 - The INSTNCT CSP has been changed from `connect-src 'none'; form-action 'none'` to the exact Worker origin.
 - `scripts/audit_instnct_static_site.mjs` has been updated from forbidding the form to requiring the safe configured form.
+- `node scripts\audit_public_github_state.mjs` passes after the public page and
+  Worker deployment state are intentionally updated.
 
 Until then, the public page must keep the link-only release tracking block so users do not submit into a dead endpoint.

--- a/scripts/audit_public_surface.py
+++ b/scripts/audit_public_surface.py
@@ -130,6 +130,7 @@ REQUIRED_TRACKED_FILES = {
     ".github/workflows/public-pages-smoke.yml",
     ".github/workflows/public-surface-audit.yml",
     "CONTRIBUTING.md",
+    "DEPLOYMENT.md",
     ".gitattributes",
     ".gitignore",
     "README.md",
@@ -207,6 +208,34 @@ REQUIRED_SECURITY_MARKERS = {
     "node scripts\\audit_public_github_state.mjs",
     "before opening the final PR and",
     "again after merge",
+}
+
+REQUIRED_DEPLOYMENT_MARKERS = {
+    "Public deployment runbook",
+    "docs/index.html",
+    "docs/instnct/",
+    "node scripts\\sync_public_release_links.mjs --check",
+    "node scripts\\validate_public_release_manifests.mjs",
+    "node scripts\\validate_public_release_state.mjs",
+    "node scripts\\audit_public_secrets.mjs",
+    "node scripts\\audit_instnct_static_site.mjs",
+    "python scripts\\audit_public_surface.py",
+    "node scripts\\smoke_instnct_browser.mjs",
+    "node scripts\\smoke_public_pages_links.mjs",
+    "powershell -ExecutionPolicy Bypass -File scripts\\check_public_export.ps1",
+    "Deploy INSTNCT Notify Worker",
+    "workers/instnct-notify/wrangler.example.jsonc",
+    "workers/instnct-notify/wrangler.jsonc",
+    ".dev.vars",
+    "CLOUDFLARE_API_TOKEN",
+    "INSTNCT_NOTIFY_D1_DATABASE_ID",
+    "INSTNCT_NOTIFY_EMAIL_HASH_PEPPER",
+    "INSTNCT_NOTIFY_ADMIN_TOKEN",
+    "scripts\\smoke_instnct_notify_live.mjs",
+    "node scripts\\audit_public_github_state.mjs",
+    "Do not add an active email form",
+    "connect-src 'none'; form-action 'none'",
+    "link-only release tracking block",
 }
 
 REQUIRED_DEPENDABOT_MARKERS = {
@@ -473,6 +502,11 @@ def main() -> int:
     for required in sorted(REQUIRED_SECURITY_MARKERS):
         if required not in security_doc:
             failures.append(f"security doc missing public-security marker: {required}")
+
+    deployment_doc = read_text(ROOT / "DEPLOYMENT.md")
+    for required in sorted(REQUIRED_DEPLOYMENT_MARKERS):
+        if required not in deployment_doc:
+            failures.append(f"deployment doc missing public-deployment marker: {required}")
 
     dependabot_config = read_text(ROOT / ".github" / "dependabot.yml")
     for required in sorted(REQUIRED_DEPENDABOT_MARKERS):


### PR DESCRIPTION
## Summary
- Align `DEPLOYMENT.md` with the public release/readiness gates for static site changes.
- Add explicit no-commit guidance for generated Wrangler config, `.dev.vars`, real D1 ids, Worker secrets, API tokens, and operator export data.
- Add post-deploy and frontend-form switch checks for Worker deployment state and `audit_public_github_state`.
- Make `scripts/audit_public_surface.py` guard deployment runbook markers and require `DEPLOYMENT.md` in the tracked public contract.

## Safety
- No website, artifact, release claim, crate code, Worker behavior, or deployment workflow behavior changed.
- Reduces public deployment drift and private config leakage risk before the training release lands.

## Validation
- `python scripts/audit_public_surface.py`
- `node scripts/audit_public_secrets.mjs`
- `node scripts/validate_public_release_state.mjs`
- `node scripts/validate_public_release_manifests.mjs`
- `node scripts/sync_public_release_links.mjs --check`
- `node scripts/audit_instnct_notify_worker.mjs`
- `node scripts/audit_instnct_static_site.mjs`
- `git diff --check`
- `powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1`