### PR TITLE
[codex] Guard Worker local config docs

### DIFF
--- a/scripts/audit_instnct_notify_worker.mjs
+++ b/scripts/audit_instnct_notify_worker.mjs
@@ -157,7 +157,20 @@ function assertSourceGuards() {
   ]) {
     assert.equal(deployWorkflow.includes(token), true, `deploy workflow missing ${token}`);
   }
-  for (const token of ["npx wrangler secret put ADMIN_TOKEN", "GET /admin/notify/export", "cleanup-rate-limits", "scheduled cleanup trigger"]) {
+  for (const token of [
+    "npx wrangler secret put ADMIN_TOKEN",
+    "GET /admin/notify/export",
+    "cleanup-rate-limits",
+    "scheduled cleanup trigger",
+    "Local config hygiene",
+    "Do not\ncommit local config or operator output",
+    "`wrangler.jsonc`",
+    ".dev.vars",
+    "real D1 database ids",
+    "operator export/delete output",
+    "node scripts\\audit_public_secrets.mjs",
+    "node scripts\\audit_instnct_notify_worker.mjs",
+  ]) {
     assert.equal(readme.includes(token), true, `worker README missing ${token}`);
   }
 }

--- a/workers/instnct-notify/README.md
+++ b/workers/instnct-notify/README.md
@@ -38,6 +38,21 @@ npx wrangler deploy
 
 Keep `EMAIL_HASH_PEPPER` out of source control. Use a long random value and rotate it only with a planned duplicate-handling migration.
 
+## Local config hygiene
+
+`wrangler.jsonc` is generated operator config, not public repo state. Do not
+commit local config or operator output: `wrangler.jsonc`, `.wrangler/`,
+`.dev.vars`, real D1 database ids, Worker secret values, API tokens, or
+operator export/delete output.
+
+Before opening a PR that touches Worker deploy docs or config, run these from
+the repo root:
+
+```powershell
+node scripts\audit_public_secrets.mjs
+node scripts\audit_instnct_notify_worker.mjs
+```
+
 ## Required config
 
 - `ALLOWED_ORIGIN`: comma-separated browser origins allowed to call the API. Default target: `https://vraxion.github.io`.


### PR DESCRIPTION
## Summary
- Add a Worker README section that explicitly keeps generated Wrangler config, `.dev.vars`, real D1 ids, Worker secrets, API tokens, and operator export/delete output out of the public repo.
- Add repo-root audit commands to run before Worker deploy doc/config PRs.
- Extend `scripts/audit_instnct_notify_worker.mjs` so the Worker README local-config hygiene markers are required.

## Safety
- No Worker runtime behavior, public website behavior, release claims, or deployment workflow behavior changed.
- This only tightens public repo documentation and the existing Worker audit guard against config/secret drift.

## Validation
- `node scripts/audit_instnct_notify_worker.mjs`
- `node scripts/audit_public_secrets.mjs`
- `python scripts/audit_public_surface.py`
- `git diff --check`
- `powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1`