### PR TITLE
[codex] Harden public workflow hygiene

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   static-site:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
@@ -45,6 +50,7 @@ jobs:
 
   rust:
     runs-on: windows-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/deploy-instnct-notify.yml
+++ b/.github/workflows/deploy-instnct-notify.yml
@@ -6,6 +6,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: deploy-instnct-notify-production
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/public-pages-smoke.yml
+++ b/.github/workflows/public-pages-smoke.yml
@@ -8,9 +8,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: public-pages-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   live-links:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6

--- a/.github/workflows/public-surface-audit.yml
+++ b/.github/workflows/public-surface-audit.yml
@@ -10,9 +10,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6

--- a/scripts/audit_public_surface.py
+++ b/scripts/audit_public_surface.py
@@ -350,6 +350,34 @@ REQUIRED_WORKFLOW_PERMISSION_MARKERS = {
     ".github/workflows/public-surface-audit.yml": "permissions:\n  contents: read",
 }
 
+REQUIRED_WORKFLOW_OPERATIONAL_MARKERS = {
+    ".github/workflows/ci.yml": {
+        "concurrency:",
+        "group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}",
+        "cancel-in-progress: true",
+        "timeout-minutes: 20",
+        "timeout-minutes: 45",
+    },
+    ".github/workflows/public-surface-audit.yml": {
+        "concurrency:",
+        "group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}",
+        "cancel-in-progress: true",
+        "timeout-minutes: 10",
+    },
+    ".github/workflows/public-pages-smoke.yml": {
+        "concurrency:",
+        "group: public-pages-smoke-${{ github.ref }}",
+        "cancel-in-progress: true",
+        "timeout-minutes: 10",
+    },
+    ".github/workflows/deploy-instnct-notify.yml": {
+        "concurrency:",
+        "group: deploy-instnct-notify-production",
+        "cancel-in-progress: false",
+        "timeout-minutes: 20",
+    },
+}
+
 REQUIRED_PUBLIC_SURFACE_AUDIT_WORKFLOW_MARKERS = {
     "Validate public release manifests",
     "Validate public release state",
@@ -549,6 +577,14 @@ def main() -> int:
             if forbidden in workflow_lower:
                 failures.append(
                     f"workflow contains forbidden write permission {forbidden!r}: {relative_path}"
+                )
+
+    for relative_path, markers in sorted(REQUIRED_WORKFLOW_OPERATIONAL_MARKERS.items()):
+        workflow_text = read_text(ROOT / relative_path)
+        for required in sorted(markers):
+            if required not in workflow_text:
+                failures.append(
+                    f"workflow missing operational hygiene marker {required!r}: {relative_path}"
                 )
 
     public_surface_workflow = read_text(


### PR DESCRIPTION
## Summary
- Add concurrency cancellation to PR/push public CI and public audit workflows so stale checks do not pile up.
- Add job timeouts to public CI, public audit, and live Pages smoke jobs.
- Add fixed non-cancelling concurrency to the manual INSTNCT Notify Worker production deploy workflow.
- Extend `scripts/audit_public_surface.py` so workflow concurrency and timeout markers remain guarded.

## Safety
- No public website, Worker runtime, release claim, crate code, manifest, artifact, or deployment command behavior changed.
- Workflow permissions stay read-only except for external deploy secrets already handled by the manual deploy workflow.
- The deploy workflow keeps `cancel-in-progress: false` to avoid interrupting an in-flight production deploy.

## Validation
- PyYAML parse pass for all `.github/workflows/*.yml`
- `python scripts/audit_public_surface.py`
- `node scripts/audit_public_secrets.mjs`
- `git diff --check`
- `powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1`