### PR TITLE
[codex] Guard public metadata log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2026-07-06
+
+- Guarded release-link sync coverage, contributor gates, security policy, and
+  deployment runbook markers in the public surface audit.
+- Added explicit public deployment guidance for generated Wrangler config,
+  `.dev.vars`, real D1 ids, Worker secrets, API tokens, and operator output.
+- Added Worker local config hygiene notes and audit coverage so generated
+  operator config and export/delete output stay out of the public repo.
+- Hardened public workflow hygiene with CI concurrency controls, job timeouts,
+  and audit markers for workflow drift.
+- Re-verified the public export guard, live Pages state, public link smoke, and
+  main GitHub Actions after each public hardening merge.
+
 ## 2026-07-05
 
 - Polished the public Pages surface and 404 fallback while keeping unreleased

--- a/scripts/audit_public_surface.py
+++ b/scripts/audit_public_surface.py
@@ -129,10 +129,14 @@ REQUIRED_TRACKED_FILES = {
     ".github/workflows/deploy-instnct-notify.yml",
     ".github/workflows/public-pages-smoke.yml",
     ".github/workflows/public-surface-audit.yml",
+    "CHANGELOG.md",
+    "CITATION.cff",
+    "CODE_OF_CONDUCT.md",
     "CONTRIBUTING.md",
     "DEPLOYMENT.md",
     ".gitattributes",
     ".gitignore",
+    "LICENSE",
     "README.md",
     "PUBLIC_BOUNDARY.md",
     "PACKAGE_BOUNDARY.md",
@@ -151,6 +155,35 @@ REQUIRED_TRACKED_FILES = {
     "LICENSE_BOUNDARY.md",
     "SECURITY.md",
     "SUPPORT.md",
+    "TRADEMARK_POLICY.md",
+}
+
+REQUIRED_CHANGELOG_MARKERS = {
+    "## 2026-07-06",
+    "release-link sync coverage",
+    "contributor gates",
+    "security policy",
+    "deployment runbook",
+    "generated Wrangler config",
+    ".dev.vars",
+    "Worker secrets",
+    "Worker local config hygiene",
+    "operator config and export/delete output",
+    "workflow hygiene",
+    "CI concurrency controls",
+    "job timeouts",
+    "public export guard",
+    "live Pages state",
+    "main GitHub Actions",
+}
+
+REQUIRED_CITATION_MARKERS = {
+    "cff-version: 1.2.0",
+    "If you use this public SDK/docs release, cite VRAXION.",
+    'title: "VRAXION Public SDK"',
+    'repository-code: "https://github.com/VRAXION/VRAXION"',
+    'license: "LicenseRef-VRAXION-Community-Source-1.0"',
+    'date-released: "2026-06-28"',
 }
 
 REQUIRED_PR_TEMPLATE_MARKERS = {
@@ -515,6 +548,16 @@ def main() -> int:
     for required in sorted(REQUIRED_TRACKED_FILES):
         if required not in file_set:
             failures.append(f"required public repo file is missing: {required}")
+
+    changelog = read_text(ROOT / "CHANGELOG.md")
+    for required in sorted(REQUIRED_CHANGELOG_MARKERS):
+        if required not in changelog:
+            failures.append(f"changelog missing public hardening marker: {required}")
+
+    citation = read_text(ROOT / "CITATION.cff")
+    for required in sorted(REQUIRED_CITATION_MARKERS):
+        if required not in citation:
+            failures.append(f"citation metadata missing marker: {required}")
 
     pr_template = read_text(ROOT / ".github" / "pull_request_template.md")
     for required in sorted(REQUIRED_PR_TEMPLATE_MARKERS):


### PR DESCRIPTION
## Summary
- Add a `2026-07-06` changelog section for the public hardening work: release-link sync, contributor/security/deployment guards, Worker local config hygiene, workflow hygiene, and post-merge verification.
- Make `scripts/audit_public_surface.py` require the public metadata files that should stay present: `CHANGELOG.md`, `CITATION.cff`, `CODE_OF_CONDUCT.md`, `LICENSE`, and `TRADEMARK_POLICY.md`.
- Add audit markers for changelog hardening notes and citation metadata.

## Safety
- No public website, Worker runtime, crate code, release claim, manifest, artifact, or workflow behavior changed.
- This only improves public metadata traceability and guards the metadata from accidental removal/drift.

## Validation
- `python scripts/audit_public_surface.py`
- `node scripts/audit_public_secrets.mjs`
- `git diff --check`
- `powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1`