### PR TITLE
[codex] Enforce security.txt in live smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Hardened public workflow hygiene with CI concurrency controls, job timeouts,
   and audit markers for workflow drift.
 - Added a public security.txt endpoint and audit coverage for vulnerability disclosure routing.
+- Added live security.txt smoke coverage for the public Pages disclosure endpoint.
 - Re-verified the public export guard, live Pages state, public link smoke, and
   main GitHub Actions after each public hardening merge.
 

--- a/scripts/audit_public_surface.py
+++ b/scripts/audit_public_surface.py
@@ -177,6 +177,7 @@ REQUIRED_CHANGELOG_MARKERS = {
     "live Pages state",
     "main GitHub Actions",
     "security.txt endpoint",
+    "live security.txt smoke coverage",
     "vulnerability disclosure routing",
 }
 
@@ -349,6 +350,14 @@ REQUIRED_RELEASE_LINK_SYNC_MARKERS = {
     "docs/CURRENT_CAPABILITIES.md",
     "current-state release link file is not scanned",
     "public_release_link_files",
+}
+
+REQUIRED_PUBLIC_PAGES_SMOKE_MARKERS = {
+    "securityTxtUrl",
+    "validateSecurityTxt",
+    "Contact: https://github.com/VRAXION/VRAXION/security/policy",
+    "security.txt Expires timestamp must stay within one year",
+    "`${baseUrl}/.well-known/security.txt`",
 }
 
 REQUIRED_RELEASE_MANIFEST_EXCLUSIONS = {
@@ -662,6 +671,11 @@ def main() -> int:
     for required in sorted(REQUIRED_RELEASE_LINK_SYNC_MARKERS):
         if required not in release_link_sync:
             failures.append(f"release link sync missing coverage marker: {required}")
+
+    public_pages_smoke = read_text(ROOT / "scripts" / "smoke_public_pages_links.mjs")
+    for required in sorted(REQUIRED_PUBLIC_PAGES_SMOKE_MARKERS):
+        if required not in public_pages_smoke:
+            failures.append(f"public Pages smoke missing security.txt marker: {required}")
 
     gitattributes_path = ROOT / ".gitattributes"
     gitattributes_entries = {

--- a/scripts/smoke_public_pages_links.mjs
+++ b/scripts/smoke_public_pages_links.mjs
@@ -135,6 +135,34 @@ function sitemapHasDatedUrl(sitemap, url, date) {
   return new RegExp(`<loc>${escapeRegExp(url)}</loc>\\s*<lastmod>${escapeRegExp(date)}</lastmod>`).test(sitemap);
 }
 
+function validateSecurityTxt(securityTxt) {
+  for (const required of [
+    "Contact: https://github.com/VRAXION/VRAXION/security/policy",
+    "Policy: https://github.com/VRAXION/VRAXION/security/policy",
+    "Preferred-Languages: en, hu",
+    `Canonical: ${canonicalBaseUrl}/.well-known/security.txt`,
+  ]) {
+    if (!securityTxt.includes(required)) fail(`security.txt missing required field: ${required}`);
+  }
+
+  const expiresMatch = securityTxt.match(/^Expires:\s*(\S+)\s*$/m);
+  if (!expiresMatch) {
+    fail("security.txt must include an Expires timestamp");
+    return;
+  }
+
+  const expiresAt = Date.parse(expiresMatch[1]);
+  if (!Number.isFinite(expiresAt)) {
+    fail(`security.txt Expires timestamp is invalid: ${expiresMatch[1]}`);
+    return;
+  }
+
+  const now = Date.now();
+  const oneYearMs = 366 * 24 * 60 * 60 * 1000;
+  if (expiresAt <= now) fail("security.txt Expires timestamp must stay in the future");
+  if (expiresAt > now + oneYearMs) fail("security.txt Expires timestamp must stay within one year");
+}
+
 function attr(tag, name) {
   const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const pattern = new RegExp(`\\s${escaped}=(["'])(.*?)\\1`, "i");
@@ -167,6 +195,7 @@ const anchorcellUrl = `${baseUrl}/anchorcell/`;
 const hiddenSurfaceUrl = `${baseUrl}/${hiddenSurfaceSlug}/`;
 const robotsUrl = `${baseUrl}/robots.txt`;
 const sitemapUrl = `${baseUrl}/sitemap.xml`;
+const securityTxtUrl = `${baseUrl}/.well-known/security.txt`;
 const versionUrl = `${baseUrl}/VERSION.json`;
 
 const home = await fetchText(homeUrl, "home");
@@ -174,6 +203,7 @@ const instnct = await fetchText(instnctUrl, "INSTNCT");
 const anchorcell = await fetchText(anchorcellUrl, "AnchorCell");
 const robots = await fetchText(robotsUrl, "robots.txt");
 const sitemap = await fetchText(sitemapUrl, "sitemap.xml");
+const securityTxt = await fetchText(securityTxtUrl, "security.txt");
 const versionText = await fetchText(versionUrl, "VERSION.json");
 let latestRelease = "";
 let versionDate = "";
@@ -313,6 +343,7 @@ if (instnct && new RegExp(`href=["'][^"']*${hiddenSurfaceSlug}/|hidden roadmap`,
 }
 if (hiddenSurfaceStatus !== 404) fail(`hidden roadmap surface URL must be absent from Pages, got HTTP ${hiddenSurfaceStatus}`);
 if (robots && !robots.includes(`${canonicalBaseUrl}/sitemap.xml`)) fail("robots.txt does not point at the live sitemap");
+if (securityTxt) validateSecurityTxt(securityTxt);
 for (const url of [`${canonicalBaseUrl}/`, `${canonicalBaseUrl}/instnct/`, `${canonicalBaseUrl}/anchorcell/`]) {
   if (sitemap && !sitemap.includes(`<loc>${url}</loc>`)) fail(`sitemap.xml does not include ${url}`);
   if (sitemap && versionDate && !sitemapHasDatedUrl(sitemap, url, versionDate)) {
@@ -327,6 +358,7 @@ const urls = new Set([
   ...collectUrls(anchorcell, anchorcellUrl),
   `${baseUrl}/robots.txt`,
   `${baseUrl}/sitemap.xml`,
+  `${baseUrl}/.well-known/security.txt`,
   ...(latestRelease
     ? [
         `https://github.com/VRAXION/VRAXION/releases/tag/${latestRelease}`,


### PR DESCRIPTION
## Summary

- makes the live public Pages smoke fetch `/.well-known/security.txt`
- validates the disclosure `Contact`, `Policy`, language, `Canonical`, and `Expires` fields
- adds public surface audit markers so the live security.txt coverage cannot drift silently

## Validation

- `node --check scripts\smoke_public_pages_links.mjs`
- `node scripts\smoke_public_pages_links.mjs`
- `python scripts\audit_public_surface.py`
- `node scripts\audit_public_secrets.mjs`
- `git diff --check`
- `powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1`