### PR TITLE
[codex] Scrub internal runtime wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   and audit markers for workflow drift.
 - Added a public security.txt endpoint and audit coverage for vulnerability disclosure routing.
 - Added live security.txt smoke coverage for the public Pages disclosure endpoint.
+- Replaced internal runtime wording in the public crate with operator-side wording.
 - Re-verified the public export guard, live Pages state, public link smoke, and
   main GitHub Actions after each public hardening merge.
 

--- a/crates/alphasync-runtime/README.md
+++ b/crates/alphasync-runtime/README.md
@@ -3,11 +3,10 @@
 `alphasync-runtime` contains the public-candidate AlphaSync runtime CLI and safe
 synthetic runtime examples built on top of `alphasync-core`.
 
-The crate is limited to local smoke/runtime behavior. It does not include the
-private runtime GUI, private frontier traces, raw datasets, or private
-skillstore persistence. It also does not include the private golden engine,
-training, mutation, skill registry, artifact writer internals, or diagnostic
-parity binaries.
+The crate is limited to local smoke/runtime behavior. It intentionally excludes
+non-public operator interfaces, frontier traces, raw datasets, persistence
+services, golden-engine internals, training, mutation, skill registry,
+artifact writer internals, and diagnostic parity binaries.
 
 This crate remains a compatibility public-candidate source crate. Any future
 golden-backed binary, API, SaaS, or wrapper path requires separate release

--- a/crates/alphasync-runtime/src/artifact_writer.rs
+++ b/crates/alphasync-runtime/src/artifact_writer.rs
@@ -161,9 +161,9 @@ impl RuntimeArtifactSnapshot {
 
 /// Atomic process-crash runtime artifact writer.
 ///
-/// This writer is deliberately small. It mirrors the private Python frontier
-/// artifact rule: write a full temp file, flush it, replace the target, and
-/// expose a checksum record. The v0.1 guarantee is coherent visibility after
+/// This writer is deliberately small. It follows the crate's public artifact
+/// rule: write a full temp file, flush it, replace the target, and expose a
+/// checksum record. The v0.1 guarantee is coherent visibility after
 /// ordinary process crashes; sudden OS or power loss directory-entry durability
 /// is explicitly outside the public claim on platforms that do not expose a
 /// portable fallible directory sync through stable Rust.

--- a/crates/alphasync-runtime/src/logic_iq.rs
+++ b/crates/alphasync-runtime/src/logic_iq.rs
@@ -45,8 +45,8 @@ pub const DEFAULT_LOGIC_IQ_CONSENSUS_SCENE_WRITE_EVERY: usize = 1;
 
 /// Default self-contained output directory for Logic-IQ runtime artifacts.
 ///
-/// The private GUI may monitor this folder, but the public runner must not have
-/// a default path that points into the private monitor tree.
+/// Operator tooling may monitor this folder, but the public runner keeps a
+/// self-contained default path instead of pointing into an operator workspace.
 pub const DEFAULT_LOGIC_IQ_RUN_DIR: &str = "runtime_runs/logic_iq_current";
 
 const TASK_CELL: CellAddress = CellAddress::new(0, 0, 0);

--- a/crates/alphasync-runtime/src/main.rs
+++ b/crates/alphasync-runtime/src/main.rs
@@ -1,8 +1,8 @@
 //! Canonical local `α-Sync` runtime CLI.
 //!
-//! This binary is the stable entrypoint for private runtime smoke/scene
-//! artifact generation. It does not read datasets, perform training, publish
-//! results, or call the network.
+//! This binary is the stable entrypoint for local runtime smoke/scene artifact
+//! generation. It does not read datasets, perform training, publish results, or
+//! call the network.
 
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]

--- a/crates/alphasync-runtime/src/synthetic.rs
+++ b/crates/alphasync-runtime/src/synthetic.rs
@@ -3,7 +3,7 @@
 //! These helpers are the canonical local smoke/scene producers used by the
 //! CLI and examples. They do not read datasets, infer semantic truth, or call
 //! external services. Each function writes the same safe artifact set expected
-//! by the private runtime GUI.
+//! by local operator tooling.
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;

--- a/scripts/audit_public_surface.py
+++ b/scripts/audit_public_surface.py
@@ -50,6 +50,14 @@ FORBIDDEN_TEXT = [
     marker("private ", "dataset"),
     marker("S:", "\\"),
     marker("C:", "\\"),
+    marker("private runtime ", "GUI"),
+    marker("private Python ", "frontier"),
+    marker("private ", "GUI"),
+    marker("private monitor ", "tree"),
+    marker("private runtime smoke", "/scene"),
+    marker("private frontier ", "traces"),
+    marker("private skillstore ", "persistence"),
+    marker("private golden ", "engine"),
 ]
 
 FORBIDDEN_TEXT_REGEX = [
@@ -178,6 +186,8 @@ REQUIRED_CHANGELOG_MARKERS = {
     "main GitHub Actions",
     "security.txt endpoint",
     "live security.txt smoke coverage",
+    "internal runtime wording",
+    "operator-side wording",
     "vulnerability disclosure routing",
 }
 

--- a/scripts/check_public_export.ps1
+++ b/scripts/check_public_export.ps1
@@ -305,7 +305,15 @@ $privateTextLiteralFragments = @(
     ("Fineweb" + " edu"),
     ("OPENAI_" + "API_KEY"),
     ("ANTHROPIC_" + "API_KEY"),
-    ("GITHUB_" + "TOKEN")
+    ("GITHUB_" + "TOKEN"),
+    ("private runtime " + "GUI"),
+    ("private Python " + "frontier"),
+    ("private " + "GUI"),
+    ("private monitor " + "tree"),
+    ("private runtime smoke" + "/scene"),
+    ("private frontier " + "traces"),
+    ("private skillstore " + "persistence"),
+    ("private golden " + "engine")
 )
 $privateTextRegexFragments = @(
     ("BEGIN " + ".*PRIVATE" + " KEY"),


### PR DESCRIPTION
## Summary

- replaces internal-sounding runtime wording in the public `alphasync-runtime` crate with neutral operator-side/public wording
- adds guard coverage for the removed phrases in both public surface audit and the full public export private-text scan
- records the public hardening change in the changelog

## Validation

- `rg -n "private runtime GUI|private Python frontier|private GUI|private monitor tree|private runtime smoke/scene|private frontier traces|private skillstore persistence|private golden engine" crates docs README.md scripts .github releases workers` returned no matches
- `python scripts\audit_public_surface.py`
- `node scripts\audit_public_secrets.mjs`
- `git diff --check`
- `powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1`