### PR TITLE
[codex] Add public link audit

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,6 +20,7 @@
 - [ ] `node scripts\validate_public_release_manifests.mjs`
 - [ ] `node scripts\validate_public_release_state.mjs`
 - [ ] `node scripts\audit_public_github_state.mjs` was run before opening this release PR, or this PR does not change public release state.
+- [ ] `node scripts\audit_public_links.mjs`
 - [ ] `node scripts\audit_public_secrets.mjs`
 - [ ] `node scripts\audit_instnct_static_site.mjs`
 - [ ] `node scripts\audit_instnct_notify_worker.mjs`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           node --check scripts/audit_instnct_static_site.mjs
           node --check scripts/audit_instnct_notify_worker.mjs
           node --check scripts/audit_public_github_state.mjs
+          node --check scripts/audit_public_links.mjs
           node --check scripts/audit_public_secrets.mjs
           node --check scripts/sync_public_release_links.mjs
           node --check scripts/validate_public_release_manifests.mjs
@@ -39,6 +40,7 @@ jobs:
           node scripts/sync_public_release_links.mjs --check
           node scripts/validate_public_release_manifests.mjs
           node scripts/validate_public_release_state.mjs
+          node scripts/audit_public_links.mjs
           node scripts/audit_public_secrets.mjs
           node scripts/audit_instnct_static_site.mjs
           node scripts/audit_instnct_notify_worker.mjs

--- a/.github/workflows/public-surface-audit.yml
+++ b/.github/workflows/public-surface-audit.yml
@@ -32,6 +32,8 @@ jobs:
         run: node scripts/validate_public_release_state.mjs
       - name: Sync public release links
         run: node scripts/sync_public_release_links.mjs --check
+      - name: Audit public links
+        run: node scripts/audit_public_links.mjs
       - name: Audit public secrets
         run: node scripts/audit_public_secrets.mjs
       - name: Audit public surface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added a public security.txt endpoint and audit coverage for vulnerability disclosure routing.
 - Added live security.txt smoke coverage for the public Pages disclosure endpoint.
 - Replaced internal runtime wording in the public crate with operator-side wording.
+- Added a public link audit for repo-local and Pages-local documentation links.
 - Re-verified the public export guard, live Pages state, public link smoke, and
   main GitHub Actions after each public hardening merge.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Before opening a pull request, run:
 node scripts\sync_public_release_links.mjs --check
 node scripts\validate_public_release_manifests.mjs
 node scripts\validate_public_release_state.mjs
+node scripts\audit_public_links.mjs
 node scripts\audit_public_secrets.mjs
 node scripts\audit_instnct_static_site.mjs
 node scripts\audit_instnct_notify_worker.mjs

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -25,6 +25,7 @@ Required local gates before pushing public site changes:
 node scripts\sync_public_release_links.mjs --check
 node scripts\validate_public_release_manifests.mjs
 node scripts\validate_public_release_state.mjs
+node scripts\audit_public_links.mjs
 node scripts\audit_public_secrets.mjs
 node scripts\audit_instnct_static_site.mjs
 python scripts\audit_public_surface.py

--- a/PUBLIC_RELEASE_CHECKLIST.md
+++ b/PUBLIC_RELEASE_CHECKLIST.md
@@ -99,6 +99,7 @@ node scripts\audit_public_github_state.mjs
 node scripts\sync_public_release_links.mjs --check
 node scripts\validate_public_release_manifests.mjs
 node scripts\validate_public_release_state.mjs
+node scripts\audit_public_links.mjs
 node scripts\audit_public_secrets.mjs
 node scripts\audit_instnct_static_site.mjs
 node scripts\audit_instnct_notify_worker.mjs

--- a/releases/README.md
+++ b/releases/README.md
@@ -37,6 +37,7 @@ node scripts\audit_public_github_state.mjs
 node scripts\sync_public_release_links.mjs --check
 node scripts\validate_public_release_manifests.mjs
 node scripts\validate_public_release_state.mjs
+node scripts\audit_public_links.mjs
 node scripts\audit_public_secrets.mjs
 python scripts\audit_public_surface.py
 node scripts\smoke_public_pages_links.mjs

--- a/releases/public-release-manifest.example.json
+++ b/releases/public-release-manifest.example.json
@@ -39,6 +39,7 @@
       "node scripts\\sync_public_release_links.mjs --check",
       "node scripts\\validate_public_release_manifests.mjs",
       "node scripts\\validate_public_release_state.mjs",
+      "node scripts\\audit_public_links.mjs",
       "node scripts\\audit_public_secrets.mjs",
       "python scripts\\audit_public_surface.py",
       "node scripts\\smoke_public_pages_links.mjs",

--- a/releases/public-sdk-p11-20260629.manifest.json
+++ b/releases/public-sdk-p11-20260629.manifest.json
@@ -53,6 +53,7 @@
       "node scripts\\sync_public_release_links.mjs --check",
       "node scripts\\validate_public_release_manifests.mjs",
       "node scripts\\validate_public_release_state.mjs",
+      "node scripts\\audit_public_links.mjs",
       "node scripts\\audit_public_secrets.mjs",
       "python scripts\\audit_public_surface.py",
       "node scripts\\smoke_public_pages_links.mjs",

--- a/scripts/audit_public_links.mjs
+++ b/scripts/audit_public_links.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const pagesBaseUrl = "https://vraxion.github.io/VRAXION/";
+const githubBlobPrefix = "https://github.com/VRAXION/VRAXION/blob/main/";
+const scannedExtensions = new Set([".md", ".html", ".yml", ".yaml"]);
+const markdownExtensions = new Set([".md"]);
+const htmlExtensions = new Set([".html"]);
+const yamlExtensions = new Set([".yml", ".yaml"]);
+const failures = [];
+
+const trackedFiles = execFileSync("git", ["ls-files"], { cwd: root, encoding: "utf8" })
+  .split(/\r?\n/)
+  .map((line) => line.trim().replaceAll("\\", "/"))
+  .filter(Boolean);
+const trackedFileSet = new Set(trackedFiles);
+const trackedDirSet = new Set(["."]);
+
+for (const file of trackedFiles) {
+  const parts = file.split("/");
+  for (let index = 1; index < parts.length; index += 1) {
+    trackedDirSet.add(parts.slice(0, index).join("/"));
+  }
+}
+
+function fail(relativePath, line, message) {
+  failures.push(`${relativePath}:${line}: ${message}`);
+}
+
+function lineNumber(text, index) {
+  return text.slice(0, index).split(/\r?\n/).length;
+}
+
+function isExternalReference(target) {
+  return /^(?:https?:|mailto:|tel:|data:|javascript:)/i.test(target);
+}
+
+function withoutFragmentAndQuery(target) {
+  return target.split("#", 1)[0].split("?", 1)[0];
+}
+
+function normalizeRepoPath(candidate) {
+  return path.posix.normalize(candidate.replaceAll("\\", "/")).replace(/^\.\//, "").replace(/\/+$/, "");
+}
+
+function trackedTargetExists(repoPath) {
+  const normalized = normalizeRepoPath(repoPath);
+  if (!normalized || normalized === ".") return true;
+  if (trackedFileSet.has(normalized) || trackedDirSet.has(normalized)) return true;
+  if (trackedFileSet.has(`${normalized}/index.html`)) return true;
+  return false;
+}
+
+function checkRepoPath(relativePath, line, repoPath, originalTarget) {
+  if (/[A-Za-z]:[\\/]|^\/\//.test(repoPath)) {
+    fail(relativePath, line, `local link uses an absolute machine path: ${originalTarget}`);
+    return;
+  }
+  const normalized = normalizeRepoPath(repoPath);
+  if (normalized.startsWith("../") || normalized.includes("/../")) {
+    fail(relativePath, line, `local link escapes the public repository: ${originalTarget}`);
+    return;
+  }
+  if (!trackedTargetExists(normalized)) {
+    fail(relativePath, line, `local link target is missing: ${originalTarget}`);
+  }
+}
+
+function checkPagesUrl(relativePath, line, target) {
+  const url = new URL(target);
+  if (url.origin !== "https://vraxion.github.io" || !url.pathname.startsWith("/VRAXION/")) return;
+  const pagesPath = decodeURIComponent(url.pathname.slice("/VRAXION/".length));
+  const docsPath = pagesPath ? `docs/${pagesPath}` : "docs/index.html";
+  checkRepoPath(relativePath, line, docsPath.endsWith("/") ? `${docsPath}index.html` : docsPath, target);
+}
+
+function checkGithubBlobUrl(relativePath, line, target) {
+  if (!target.startsWith(githubBlobPrefix)) return;
+  const repoPath = decodeURIComponent(withoutFragmentAndQuery(target.slice(githubBlobPrefix.length)));
+  checkRepoPath(relativePath, line, repoPath, target);
+}
+
+function checkLocalTarget(relativePath, line, target) {
+  const cleanTarget = withoutFragmentAndQuery(target.trim());
+  if (!cleanTarget || cleanTarget.startsWith("#")) return;
+  if (isExternalReference(cleanTarget)) {
+    checkGithubBlobUrl(relativePath, line, cleanTarget);
+    checkPagesUrl(relativePath, line, cleanTarget);
+    return;
+  }
+
+  const baseDir = path.posix.dirname(relativePath);
+  const repoPath = cleanTarget.startsWith("/")
+    ? cleanTarget.slice(1)
+    : path.posix.join(baseDir === "." ? "" : baseDir, cleanTarget);
+  checkRepoPath(relativePath, line, repoPath, target);
+}
+
+function collectMarkdownLinks(text) {
+  const links = [];
+  for (const match of text.matchAll(/(?<!!)\[[^\]\n]+\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g)) {
+    links.push({ index: match.index ?? 0, target: match[1] });
+  }
+  return links;
+}
+
+function collectHtmlLinks(text) {
+  const links = [];
+  for (const match of text.matchAll(/\s(?:href|src)=["']([^"']+)["']/gi)) {
+    links.push({ index: match.index ?? 0, target: match[1] });
+  }
+  return links;
+}
+
+function collectYamlGithubBlobLinks(text) {
+  const links = [];
+  for (const match of text.matchAll(/https:\/\/github\.com\/VRAXION\/VRAXION\/blob\/main\/[^\s"')]+/g)) {
+    links.push({ index: match.index ?? 0, target: match[0] });
+  }
+  return links;
+}
+
+let scannedFiles = 0;
+let checkedLinks = 0;
+
+for (const relativePath of trackedFiles) {
+  const extension = path.extname(relativePath).toLowerCase();
+  if (!scannedExtensions.has(extension)) continue;
+
+  const text = fs.readFileSync(path.join(root, relativePath), "utf8");
+  const links = [];
+  if (markdownExtensions.has(extension)) links.push(...collectMarkdownLinks(text));
+  if (htmlExtensions.has(extension)) links.push(...collectHtmlLinks(text));
+  if (yamlExtensions.has(extension)) links.push(...collectYamlGithubBlobLinks(text));
+
+  scannedFiles += 1;
+  for (const link of links) {
+    checkedLinks += 1;
+    checkLocalTarget(relativePath, lineNumber(text, link.index), link.target);
+  }
+}
+
+console.log("PUBLIC_LINK_AUDIT");
+console.log(`tracked_files=${trackedFiles.length}`);
+console.log(`scanned_files=${scannedFiles}`);
+console.log(`checked_links=${checkedLinks}`);
+console.log(`failure_count=${failures.length}`);
+for (const failure of failures) console.log(`failure: ${failure}`);
+if (failures.length) process.exit(1);
+console.log("public_link_audit=pass");

--- a/scripts/audit_public_surface.py
+++ b/scripts/audit_public_surface.py
@@ -155,6 +155,7 @@ REQUIRED_TRACKED_FILES = {
     "releases/public-sdk-p11-20260629.manifest.json",
     "releases/public-release-manifest.example.json",
     "releases/public-release-manifest.schema.json",
+    "scripts/audit_public_links.mjs",
     "scripts/audit_public_secrets.mjs",
     "scripts/audit_public_github_state.mjs",
     "scripts/validate_public_release_manifests.mjs",
@@ -188,6 +189,8 @@ REQUIRED_CHANGELOG_MARKERS = {
     "live security.txt smoke coverage",
     "internal runtime wording",
     "operator-side wording",
+    "public link audit",
+    "Pages-local documentation links",
     "vulnerability disclosure routing",
 }
 
@@ -220,6 +223,7 @@ REQUIRED_PR_TEMPLATE_MARKERS = {
     "releases/public-release-manifest.schema.json",
     "node scripts\\validate_public_release_manifests.mjs",
     "node scripts\\validate_public_release_state.mjs",
+    "node scripts\\audit_public_links.mjs",
     "node scripts\\audit_public_secrets.mjs",
     "workers/instnct-notify/wrangler.jsonc",
     "powershell -ExecutionPolicy Bypass -File scripts\\check_public_export.ps1",
@@ -232,6 +236,7 @@ REQUIRED_CONTRIBUTING_MARKERS = {
     "node scripts\\sync_public_release_links.mjs --check",
     "node scripts\\validate_public_release_manifests.mjs",
     "node scripts\\validate_public_release_state.mjs",
+    "node scripts\\audit_public_links.mjs",
     "node scripts\\audit_public_secrets.mjs",
     "node scripts\\audit_instnct_static_site.mjs",
     "node scripts\\audit_instnct_notify_worker.mjs",
@@ -272,6 +277,7 @@ REQUIRED_DEPLOYMENT_MARKERS = {
     "node scripts\\sync_public_release_links.mjs --check",
     "node scripts\\validate_public_release_manifests.mjs",
     "node scripts\\validate_public_release_state.mjs",
+    "node scripts\\audit_public_links.mjs",
     "node scripts\\audit_public_secrets.mjs",
     "node scripts\\audit_instnct_static_site.mjs",
     "python scripts\\audit_public_surface.py",
@@ -350,6 +356,7 @@ REQUIRED_RELEASE_MANIFEST_README_MARKERS = {
     "private engine source",
     "non-public training data",
     "raw operator output",
+    "node scripts\\audit_public_links.mjs",
 }
 
 REQUIRED_RELEASE_LINK_SYNC_MARKERS = {
@@ -368,6 +375,15 @@ REQUIRED_PUBLIC_PAGES_SMOKE_MARKERS = {
     "Contact: https://github.com/VRAXION/VRAXION/security/policy",
     "security.txt Expires timestamp must stay within one year",
     "`${baseUrl}/.well-known/security.txt`",
+}
+
+REQUIRED_PUBLIC_LINK_AUDIT_MARKERS = {
+    "PUBLIC_LINK_AUDIT",
+    "githubBlobPrefix",
+    "pagesBaseUrl",
+    "collectMarkdownLinks",
+    "collectHtmlLinks",
+    "local link target is missing",
 }
 
 REQUIRED_RELEASE_MANIFEST_EXCLUSIONS = {
@@ -446,6 +462,8 @@ REQUIRED_PUBLIC_SURFACE_AUDIT_WORKFLOW_MARKERS = {
     "Validate public release state",
     "Sync public release links",
     "node scripts/sync_public_release_links.mjs --check",
+    "Audit public links",
+    "node scripts/audit_public_links.mjs",
     "Audit public secrets",
     "Audit public surface",
 }
@@ -682,6 +700,11 @@ def main() -> int:
         if required not in release_link_sync:
             failures.append(f"release link sync missing coverage marker: {required}")
 
+    public_link_audit = read_text(ROOT / "scripts" / "audit_public_links.mjs")
+    for required in sorted(REQUIRED_PUBLIC_LINK_AUDIT_MARKERS):
+        if required not in public_link_audit:
+            failures.append(f"public link audit missing marker: {required}")
+
     public_pages_smoke = read_text(ROOT / "scripts" / "smoke_public_pages_links.mjs")
     for required in sorted(REQUIRED_PUBLIC_PAGES_SMOKE_MARKERS):
         if required not in public_pages_smoke:
@@ -832,6 +855,10 @@ def main() -> int:
         "scripts\\audit_public_secrets.mjs" in command for command in commands
     ):
         failures.append("release manifest example must include the public secret scan command")
+    if not isinstance(commands, list) or not any(
+        "scripts\\audit_public_links.mjs" in command for command in commands
+    ):
+        failures.append("release manifest example must include the public link audit command")
     if not isinstance(commands, list) or not any(
         "scripts\\smoke_public_pages_links.mjs" in command for command in commands
     ):

--- a/scripts/check_public_export.ps1
+++ b/scripts/check_public_export.ps1
@@ -422,6 +422,7 @@ try {
         "scripts\audit_instnct_notify_worker.mjs",
         "scripts\audit_instnct_static_site.mjs",
         "scripts\audit_public_github_state.mjs",
+        "scripts\audit_public_links.mjs",
         "scripts\audit_public_secrets.mjs",
         "scripts\audit_public_surface.py",
         "scripts\check_public_export.ps1",
@@ -539,6 +540,7 @@ try {
         "scripts/audit_instnct_notify_worker.mjs",
         "scripts/audit_instnct_static_site.mjs",
         "scripts/audit_public_github_state.mjs",
+        "scripts/audit_public_links.mjs",
         "scripts/audit_public_secrets.mjs",
         "scripts/audit_public_surface.py",
         "scripts/check_public_export.ps1",
@@ -631,6 +633,7 @@ try {
     Invoke-NativeChecked "node check audit_instnct_static_site" "node" @("--check", "scripts/audit_instnct_static_site.mjs")
     Invoke-NativeChecked "node check audit_instnct_notify_worker" "node" @("--check", "scripts/audit_instnct_notify_worker.mjs")
     Invoke-NativeChecked "node check audit_public_github_state" "node" @("--check", "scripts/audit_public_github_state.mjs")
+    Invoke-NativeChecked "node check audit_public_links" "node" @("--check", "scripts/audit_public_links.mjs")
     Invoke-NativeChecked "node check audit_public_secrets" "node" @("--check", "scripts/audit_public_secrets.mjs")
     Invoke-NativeChecked "node check sync_public_release_links" "node" @("--check", "scripts/sync_public_release_links.mjs")
     Invoke-NativeChecked "node check validate_public_release_manifests" "node" @("--check", "scripts/validate_public_release_manifests.mjs")
@@ -642,6 +645,7 @@ try {
     Invoke-NativeChecked "sync public release links" "node" @("scripts/sync_public_release_links.mjs", "--check")
     Invoke-NativeChecked "validate public release manifests" "node" @("scripts/validate_public_release_manifests.mjs")
     Invoke-NativeChecked "validate public release state" "node" @("scripts/validate_public_release_state.mjs")
+    Invoke-NativeChecked "public link audit" "node" @("scripts/audit_public_links.mjs")
     Invoke-NativeChecked "public secret scan" "node" @("scripts/audit_public_secrets.mjs")
     Invoke-NativeChecked "INSTNCT static audit" "node" @("scripts/audit_instnct_static_site.mjs")
     Invoke-NativeChecked "INSTNCT notify Worker audit" "node" @("scripts/audit_instnct_notify_worker.mjs")

--- a/scripts/validate_public_release_manifests.mjs
+++ b/scripts/validate_public_release_manifests.mjs
@@ -47,6 +47,7 @@ const REQUIRED_COMMANDS = [
   "node scripts\\sync_public_release_links.mjs --check",
   "node scripts\\validate_public_release_manifests.mjs",
   "node scripts\\validate_public_release_state.mjs",
+  "node scripts\\audit_public_links.mjs",
   "node scripts\\audit_public_secrets.mjs",
   "python scripts\\audit_public_surface.py",
   "node scripts\\smoke_public_pages_links.mjs",


### PR DESCRIPTION
## Summary
- add a repo-local public link audit for Markdown, HTML, GitHub blob, and Pages-local links
- wire the audit into CI, the public-surface workflow, release checklists, manifests, and the full public export guard
- guard the new audit surface from the public-surface audit so future releases keep the check in place

## Validation
- `node --check scripts\audit_public_links.mjs`
- `node scripts\audit_public_links.mjs`
- `node scripts\validate_public_release_manifests.mjs`
- `python scripts\audit_public_surface.py`
- `node scripts\sync_public_release_links.mjs --check`
- `node scripts\audit_public_secrets.mjs`
- `git diff --check --cached`
- `powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1`