### PR TITLE
[codex] Harden public README gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added live security.txt smoke coverage for the public Pages disclosure endpoint.
 - Replaced internal runtime wording in the public crate with operator-side wording.
 - Added a public link audit for repo-local and Pages-local documentation links.
+- Synced the README public gate list and scrubbed remaining internal crate wording.
 - Re-verified the public export guard, live Pages state, public link smoke, and
   main GitHub Actions after each public hardening merge.
 

--- a/PACKAGE_BOUNDARY.md
+++ b/PACKAGE_BOUNDARY.md
@@ -14,8 +14,8 @@ Excluded surfaces:
 - internal engine source
 - private data adapters
 - operational run outputs
-- skill persistence
-- diagnostic tools
+- non-public persistence services
+- non-public diagnostics
 - old research pages
 - hosted product code
 - private engine binaries or internals

--- a/PUBLIC_BOUNDARY.md
+++ b/PUBLIC_BOUNDARY.md
@@ -15,8 +15,8 @@ This repository excludes:
 - internal engine source
 - private run infrastructure
 - private data adapters
-- skill persistence
-- diagnostic tooling
+- non-public persistence services
+- non-public diagnostics
 - old public research pages
 - private engine binaries or internals
 

--- a/PUBLIC_DELIVERY_MODEL.md
+++ b/PUBLIC_DELIVERY_MODEL.md
@@ -33,7 +33,7 @@ Pages status docs
 private engine source
 private binary internals
 production training service
-skill persistence store
+non-public persistence services
 hosted SaaS availability
 medical or clinical claims
 ```

--- a/PUBLIC_RELEASE_CHECKLIST.md
+++ b/PUBLIC_RELEASE_CHECKLIST.md
@@ -52,8 +52,8 @@ The release PR must not include:
 - absolute local or UNC machine paths
 - secrets, tokens, keys, or filled production config
 - private data adapters
-- skill persistence stores
-- diagnostic parity tools
+- non-public persistence services
+- non-public diagnostics
 - unreleased draft pages under `docs/`
 
 Generated local config such as `workers/instnct-notify/wrangler.jsonc` must stay

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ promise.
 - `scripts/`
 
 The private engine implementation, non-public training data, operational run
-logs, diagnostic tooling, skill persistence, and unreleased research workspace
-are not published here.
+logs, non-public diagnostics, persistence services, and unreleased research
+workspaces are not published here.
 
 ## Release Intake
 
@@ -61,8 +61,13 @@ cargo doc --workspace --no-deps
 node scripts/validate_public_release_manifests.mjs
 node scripts/validate_public_release_state.mjs
 node scripts/sync_public_release_links.mjs --check
+node scripts/audit_public_github_state.mjs
+node scripts/audit_public_links.mjs
 node scripts/audit_public_secrets.mjs
+node scripts/audit_instnct_static_site.mjs
+node scripts/audit_instnct_notify_worker.mjs
 python scripts/audit_public_surface.py
+node scripts/smoke_public_pages_links.mjs
 powershell -ExecutionPolicy Bypass -File scripts/check_public_export.ps1
 ```
 

--- a/crates/alphasync-core/README.md
+++ b/crates/alphasync-core/README.md
@@ -4,7 +4,7 @@
 anonymous observation matrices, Prismion rules, proposal patches, consensus
 gates, evaluation admission, and progress gates.
 
-The crate is intentionally small and does not include private data, runtime GUI
-code, frontier experiment outputs, or skill persistence.
+The crate is intentionally small and does not include non-public data, operator
+interfaces, experiment outputs, persistence services, or training workflows.
 
 See the workspace `LICENSE` notice copied into this package.

--- a/crates/alphasync-runtime/README.md
+++ b/crates/alphasync-runtime/README.md
@@ -4,13 +4,13 @@
 synthetic runtime examples built on top of `alphasync-core`.
 
 The crate is limited to local smoke/runtime behavior. It intentionally excludes
-non-public operator interfaces, frontier traces, raw datasets, persistence
-services, golden-engine internals, training, mutation, skill registry,
-artifact writer internals, and diagnostic parity binaries.
+non-public operator interfaces, experiment traces, raw datasets, persistence
+services, training workflows, mutation systems, artifact-writer internals, and
+non-public diagnostic binaries.
 
 This crate remains a compatibility public-candidate source crate. Any future
-golden-backed binary, API, SaaS, or wrapper path requires separate release
+signed binary, API, SaaS, or wrapper path requires separate release
 review before it becomes public availability language. This crate is not the
-private engine source.
+non-public engine implementation.
 
 See the workspace `LICENSE` notice copied into this package.

--- a/docs/PUBLIC_SURFACE_POLICY.md
+++ b/docs/PUBLIC_SURFACE_POLICY.md
@@ -15,8 +15,8 @@ Not allowed:
 - private data adapters
 - private workspace path families
 - operational run outputs
-- skill persistence
-- diagnostic tools
+- non-public persistence services
+- non-public diagnostics
 - generated local caches or virtual environments
 - stale research status pages
 - private engine binary internals

--- a/scripts/audit_public_surface.py
+++ b/scripts/audit_public_surface.py
@@ -108,6 +108,14 @@ FORBIDDEN_PUBLIC_COPY = [
     "skill libraries",
     "make local intelligence",
     "production backend target",
+    "runtime GUI code",
+    "frontier traces",
+    "frontier experiment outputs",
+    "golden-engine",
+    "golden-backed",
+    "skill registry",
+    "skill persistence",
+    "diagnostic parity",
 ]
 
 REQUIRED_FORBIDDEN_PUBLIC_COPY_MARKERS = {
@@ -123,6 +131,12 @@ REQUIRED_FORBIDDEN_PUBLIC_COPY_MARKERS = {
     "hosted api/saas later",
     "preview live",
     "signed offline verification",
+    "runtime GUI code",
+    "golden-engine",
+    "golden-backed",
+    "skill registry",
+    "skill persistence",
+    "diagnostic parity",
 }
 
 EXPECTED_CRATES = {"alphasync-core", "alphasync-runtime"}
@@ -191,7 +205,22 @@ REQUIRED_CHANGELOG_MARKERS = {
     "operator-side wording",
     "public link audit",
     "Pages-local documentation links",
+    "README public gate list",
     "vulnerability disclosure routing",
+}
+
+REQUIRED_README_MARKERS = {
+    "Current Public State",
+    "Release Intake",
+    "node scripts/audit_public_github_state.mjs",
+    "node scripts/audit_public_links.mjs",
+    "node scripts/audit_instnct_static_site.mjs",
+    "node scripts/audit_instnct_notify_worker.mjs",
+    "node scripts/smoke_public_pages_links.mjs",
+    "python scripts/audit_public_surface.py",
+    "powershell -ExecutionPolicy Bypass -File scripts/check_public_export.ps1",
+    "non-public diagnostics",
+    "persistence services",
 }
 
 REQUIRED_SECURITY_TXT_MARKERS = {
@@ -601,6 +630,11 @@ def main() -> int:
     for required in sorted(REQUIRED_CHANGELOG_MARKERS):
         if required not in changelog:
             failures.append(f"changelog missing public hardening marker: {required}")
+
+    readme = read_text(ROOT / "README.md")
+    for required in sorted(REQUIRED_README_MARKERS):
+        if required not in readme:
+            failures.append(f"README missing public gate marker: {required}")
 
     citation = read_text(ROOT / "CITATION.cff")
     for required in sorted(REQUIRED_CITATION_MARKERS):


### PR DESCRIPTION
## Summary
- sync the root README build gate list with the current public release checks
- scrub remaining internal-sounding crate and boundary wording from public-facing docs
- extend the public surface audit so README gate drift and the scrubbed internal wording stay guarded

## Validation
- `rg -n "skill persistence|skill registry|golden-engine|golden-backed|frontier traces|frontier experiment|runtime GUI code|diagnostic parity|SDK boundary|boundary archive|source available|source-available" -S . --glob "!scripts/audit_public_surface.py"`
- `python scripts\audit_public_surface.py`
- `node scripts\audit_public_links.mjs`
- `node scripts\audit_public_secrets.mjs`
- `node scripts\validate_public_release_state.mjs`
- `node scripts\validate_public_release_manifests.mjs`
- `node scripts\sync_public_release_links.mjs --check`
- `git diff --check`
- `powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1`