### PR TITLE
[codex] Validate repo artifact checksums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Replaced internal runtime wording in the public crate with operator-side wording.
 - Added a public link audit for repo-local and Pages-local documentation links.
 - Synced the README public gate list and scrubbed remaining internal crate wording.
+- Added repo-relative artifact checksum verification to the public release manifest validator.
 - Re-verified the public export guard, live Pages state, public link smoke, and
   main GitHub Actions after each public hardening merge.
 

--- a/PUBLIC_RELEASE_CHECKLIST.md
+++ b/PUBLIC_RELEASE_CHECKLIST.md
@@ -71,6 +71,8 @@ If a public artifact is added:
 - use `proof_pack` only when the manifest includes a published `proof_pack`
   artifact
 - include SHA-256 for every published non-documentation artifact
+- for any repo-relative artifact path, verify the manifest checksum matches the
+  tracked file contents
 - include `signature_path_or_url` for every published `proof_pack` or `binary`
   artifact
 - add a public release manifest that follows

--- a/releases/README.md
+++ b/releases/README.md
@@ -21,6 +21,8 @@ Artifact-bearing releases have stricter gates:
   artifact.
 - Every published non-documentation artifact must include a lowercase SHA-256
   checksum.
+- repo-relative artifact paths are verified against the actual tracked file
+  contents, so local artifact checksums cannot drift from the manifest.
 - Published `proof_pack` and `binary` artifacts must also include
   `signature_path_or_url`.
 
@@ -28,7 +30,8 @@ Artifact-bearing releases have stricter gates:
 schema contract, so these artifact gates must stay encoded in
 `public-release-manifest.schema.json`. It also runs in-memory policy self-tests
 that must reject representative bad `artifact_release`, `proof_pack`, checksum,
-signature, and schema-drift cases before reporting `policy_self_tests`.
+repo-relative checksum mismatch, signature, and schema-drift cases before
+reporting `policy_self_tests`.
 
 Validate manifests before review:
 

--- a/scripts/audit_public_surface.py
+++ b/scripts/audit_public_surface.py
@@ -206,6 +206,7 @@ REQUIRED_CHANGELOG_MARKERS = {
     "public link audit",
     "Pages-local documentation links",
     "README public gate list",
+    "repo-relative artifact checksum verification",
     "vulnerability disclosure routing",
 }
 
@@ -380,12 +381,22 @@ REQUIRED_RELEASE_MANIFEST_README_MARKERS = {
     "published non-documentation artifact",
     "policy_self_tests",
     "policy self-tests",
+    "repo-relative artifact paths",
+    "repo-relative checksum mismatch",
     "signature_path_or_url",
     "schema contract",
     "private engine source",
     "non-public training data",
     "raw operator output",
     "node scripts\\audit_public_links.mjs",
+}
+
+REQUIRED_RELEASE_MANIFEST_VALIDATOR_MARKERS = {
+    "assertRepoRelativeArtifactSha256",
+    "sha256ForTrackedFile",
+    "does not match repo-relative artifact",
+    "local_artifact_checksum_matches",
+    "local_artifact_checksum_mismatch",
 }
 
 REQUIRED_RELEASE_LINK_SYNC_MARKERS = {
@@ -728,6 +739,11 @@ def main() -> int:
     for required in sorted(REQUIRED_RELEASE_MANIFEST_README_MARKERS):
         if required not in release_manifest_readme:
             failures.append(f"release manifest readme missing marker: {required}")
+
+    release_manifest_validator = read_text(ROOT / "scripts" / "validate_public_release_manifests.mjs")
+    for required in sorted(REQUIRED_RELEASE_MANIFEST_VALIDATOR_MARKERS):
+        if required not in release_manifest_validator:
+            failures.append(f"release manifest validator missing checksum marker: {required}")
 
     release_link_sync = read_text(ROOT / "scripts" / "sync_public_release_links.mjs")
     for required in sorted(REQUIRED_RELEASE_LINK_SYNC_MARKERS):

--- a/scripts/validate_public_release_manifests.mjs
+++ b/scripts/validate_public_release_manifests.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { execFileSync } from "node:child_process";
+import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -177,6 +178,30 @@ function assertTrackedRepoPath(file, label, value) {
   }
 }
 
+function trackedRepoPathOrNull(value) {
+  if (isHttpUrl(value) || hasLocalPathMarker(value) || !isRepoRelativePath(value)) {
+    return null;
+  }
+  return trackedFiles.has(value) ? value : null;
+}
+
+function sha256ForTrackedFile(relativePath) {
+  return crypto
+    .createHash("sha256")
+    .update(fs.readFileSync(path.join(ROOT, relativePath)))
+    .digest("hex");
+}
+
+function assertRepoRelativeArtifactSha256(file, label, relativePath, expectedSha256) {
+  const actualSha256 = sha256ForTrackedFile(relativePath);
+  if (actualSha256 !== expectedSha256) {
+    fail(
+      file,
+      `${label} does not match repo-relative artifact ${relativePath}: manifest has ${expectedSha256}, expected ${actualSha256}`,
+    );
+  }
+}
+
 function assertDate(file, releaseDate, releaseSlug) {
   if (typeof releaseDate !== "string" || !RELEASE_DATE_RE.test(releaseDate)) {
     fail(file, `release_date is invalid: ${releaseDate}`);
@@ -314,12 +339,14 @@ function validateArtifact(file, artifact, index) {
     fail(file, `artifacts[${index}].status is invalid: ${artifact.status}`);
   }
 
+  let localArtifactPath = null;
   if (typeof artifact.path_or_url !== "string" || artifact.path_or_url.trim() === "") {
     fail(file, `artifacts[${index}].path_or_url must be a non-empty string`);
   } else if (hasLocalPathMarker(artifact.path_or_url)) {
     fail(file, `artifacts[${index}].path_or_url contains a local or parent path`);
   } else if (!isHttpUrl(artifact.path_or_url)) {
     assertTrackedRepoPath(file, `artifacts[${index}].path_or_url`, artifact.path_or_url);
+    localArtifactPath = trackedRepoPathOrNull(artifact.path_or_url);
   }
 
   if (artifact.sha256 !== null && (typeof artifact.sha256 !== "string" || !SHA256_RE.test(artifact.sha256))) {
@@ -352,6 +379,15 @@ function validateArtifact(file, artifact, index) {
         artifact.signature_path_or_url,
       );
     }
+  }
+
+  if (localArtifactPath !== null && artifact.sha256 !== null) {
+    assertRepoRelativeArtifactSha256(
+      file,
+      `artifacts[${index}].sha256`,
+      localArtifactPath,
+      artifact.sha256,
+    );
   }
 
   if (typeof artifact.notes !== "string" || artifact.notes.length > 500) {
@@ -597,6 +633,40 @@ function runPolicySelfTests(schema, baseManifest) {
       runManifestNegativeSelfTest(
         "published_proof_pack_without_signature",
         "is published and must include signature_path_or_url",
+        () => validateManifest(`releases/${slug}.manifest.json`, manifest),
+      );
+    },
+    () => {
+      const slug = "public-selftest-local-sha-20990101";
+      const manifest = selfTestReleaseManifest(baseManifest, slug, "artifact_release");
+      manifest.artifacts = [
+        selfTestArtifact(slug, "other", {
+          name: "README.md",
+          path_or_url: "README.md",
+          sha256: sha256ForTrackedFile("README.md"),
+          signature_path_or_url: null,
+          notes: "In-memory validator self-test for repo-relative artifact checksums.",
+        }),
+      ];
+      runManifestPositiveSelfTest("local_artifact_checksum_matches", () => {
+        validateManifest(`releases/${slug}.manifest.json`, manifest);
+      });
+    },
+    () => {
+      const slug = "public-selftest-local-sha-mismatch-20990101";
+      const manifest = selfTestReleaseManifest(baseManifest, slug, "artifact_release");
+      manifest.artifacts = [
+        selfTestArtifact(slug, "other", {
+          name: "README.md",
+          path_or_url: "README.md",
+          sha256: "0".repeat(64),
+          signature_path_or_url: null,
+          notes: "In-memory validator self-test for repo-relative artifact checksum mismatch.",
+        }),
+      ];
+      runManifestNegativeSelfTest(
+        "local_artifact_checksum_mismatch",
+        "does not match repo-relative artifact README.md",
         () => validateManifest(`releases/${slug}.manifest.json`, manifest),
       );
     },


### PR DESCRIPTION
## Summary
- recompute SHA-256 for repo-relative artifact paths in public release manifests
- add positive and negative policy self-tests for local artifact checksum matching
- document the checksum gate in release intake docs and guard it through the public surface audit

## Validation
- `node --check scripts\validate_public_release_manifests.mjs`
- `node scripts\validate_public_release_manifests.mjs` (`policy_self_tests=9`)
- `python scripts\audit_public_surface.py`
- `node scripts\audit_public_links.mjs`
- `node scripts\audit_public_secrets.mjs`
- `node scripts\sync_public_release_links.mjs --check`
- `git diff --check`
- `powershell -ExecutionPolicy Bypass -File scripts\check_public_export.ps1`